### PR TITLE
fix(web-client): remove unused TurnEventLog import in SessionOverview

### DIFF
--- a/frontend/src/components/SessionOverview.tsx
+++ b/frontend/src/components/SessionOverview.tsx
@@ -1,4 +1,4 @@
-import type { SessionTelemetry, TurnEventLog } from '../types'
+import type { SessionTelemetry } from '../types'
 
 // ---------------------------------------------------------------------------
 // Sparkline


### PR DESCRIPTION
## Summary

- Remove unused `TurnEventLog` import from `SessionOverview.tsx`

`TurnEventLog` was imported but never referenced. `tsc -b` treats unused imports as errors (`TS6196`), causing the Docker frontend build step to fail with exit code 2.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Docker build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)