### PR TITLE
feat(api): ADR-0019 Exploration State Signals

### DIFF
--- a/backend/tavern/alembic/versions/0008_add_current_scene_id_and_time_of_day.py
+++ b/backend/tavern/alembic/versions/0008_add_current_scene_id_and_time_of_day.py
@@ -1,0 +1,111 @@
+"""add current_scene_id and time_of_day to campaign_state
+
+ADR-0019: Exploration State Signals — promotes party location from
+world_state["location"] (JSONB key) to a dedicated TEXT column and adds
+time_of_day as a dedicated column.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-06
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_VALID_TIMES = (
+    "dawn",
+    "morning",
+    "midday",
+    "afternoon",
+    "dusk",
+    "evening",
+    "night",
+    "late_night",
+)
+
+
+def upgrade() -> None:
+    # Add columns with defaults so the NOT NULL constraint is satisfied
+    op.add_column(
+        "campaign_states",
+        sa.Column("current_scene_id", sa.Text(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "campaign_states",
+        sa.Column("time_of_day", sa.String(), nullable=False, server_default="morning"),
+    )
+
+    # Populate current_scene_id from world_state->>'location', applying
+    # normalise_scene_id() logic in SQL.  Steps mirror the Python implementation:
+    #   1. TRIM + LOWER
+    #   2. Replace runs of spaces/hyphens with underscore
+    #   3. Strip non-conforming chars (keep a-z, 0-9, _)
+    #   4. Collapse consecutive underscores
+    #   5. Strip leading/trailing underscores (LEFT(TRIM))
+    #   6. Truncate to 64 chars
+    #   7. Fallback to 'unknown' if empty
+    op.execute(
+        """
+        UPDATE campaign_states
+        SET current_scene_id = COALESCE(
+            NULLIF(
+                LEFT(
+                    TRIM('_' FROM
+                        REGEXP_REPLACE(
+                            REGEXP_REPLACE(
+                                REGEXP_REPLACE(
+                                    LOWER(TRIM(COALESCE(world_state->>'location', ''))),
+                                    '[\\s\\-]+', '_', 'g'
+                                ),
+                                '[^a-z0-9_]', '', 'g'
+                            ),
+                            '_+', '_', 'g'
+                        )
+                    ),
+                    64
+                ),
+                ''
+            ),
+            'unknown'
+        )
+        """
+    )
+
+    # Populate time_of_day from world_state->>'time_of_day', validating against
+    # the enum.  Fall back to 'morning' for any unrecognised or absent value.
+    valid_times_literal = ", ".join(f"'{v}'" for v in _VALID_TIMES)
+    op.execute(
+        f"""
+        UPDATE campaign_states
+        SET time_of_day = CASE
+            WHEN world_state->>'time_of_day' IN ({valid_times_literal})
+            THEN world_state->>'time_of_day'
+            ELSE 'morning'
+        END
+        """
+    )
+
+    # Add CHECK constraint after data is populated
+    op.create_check_constraint(
+        "ck_campaign_states_time_of_day",
+        "campaign_states",
+        f"time_of_day IN ({valid_times_literal})",
+    )
+
+    # Remove server defaults now that existing rows are populated
+    op.alter_column("campaign_states", "current_scene_id", server_default=None)
+    op.alter_column("campaign_states", "time_of_day", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_campaign_states_time_of_day", "campaign_states", type_="check")
+    op.drop_column("campaign_states", "time_of_day")
+    op.drop_column("campaign_states", "current_scene_id")

--- a/backend/tavern/api/campaigns.py
+++ b/backend/tavern/api/campaigns.py
@@ -27,6 +27,7 @@ from tavern.api.schemas import (
     CampaignUpdateRequest,
     SessionResponse,
 )
+from tavern.core.scene import normalise_scene_id
 from tavern.dm.narrator import Narrator
 from tavern.models.campaign import Campaign, CampaignState
 from tavern.models.character import Character, CharacterCondition, InventoryItem
@@ -158,15 +159,44 @@ async def create_campaign(
     # Fallback values — overwritten on successful brief generation
     world_seed: str = preset["world_seed"] or ""
     scene_context: str = _FALLBACK_SCENE_CONTEXT
+    current_scene_id: str = "unknown"
+    time_of_day: str = "morning"
 
     # Attempt to generate a Claude-authored brief and opening scene (Haiku, non-blocking failure)
     try:
         brief = await narrator.generate_campaign_brief(name=body.name, tone=body.tone)
         world_seed = brief["campaign_brief"]
         scene_context = brief["opening_scene"]
-        world_state["location"] = brief["location"]
+        world_state["location"] = brief["location"]  # DEPRECATED: ADR-0019
         world_state["environment"] = brief["environment"]
-        world_state["time_of_day"] = brief["time_of_day"]
+        world_state["time_of_day"] = brief["time_of_day"]  # DEPRECATED: ADR-0019
+
+        # Derive current_scene_id from the brief's location (ADR-0019)
+        try:
+            current_scene_id = normalise_scene_id(brief["location"])
+        except ValueError:
+            logger.warning(
+                "Campaign brief location %r could not be normalised — defaulting to 'unknown'",
+                brief["location"],
+            )
+            current_scene_id = "unknown"
+
+        # Validate time_of_day from brief (ADR-0019)
+        _VALID_TIMES = {
+            "dawn",
+            "morning",
+            "midday",
+            "afternoon",
+            "dusk",
+            "evening",
+            "night",
+            "late_night",
+        }
+        if brief.get("time_of_day") in _VALID_TIMES:
+            time_of_day = brief["time_of_day"]
+        else:
+            time_of_day = "morning"
+
     except Exception as exc:
         logger.warning(
             "Campaign brief generation failed for %r (tone=%r) — using fallback: %s",
@@ -189,6 +219,8 @@ async def create_campaign(
         rolling_summary="",
         scene_context=scene_context,
         world_state=world_state,
+        current_scene_id=current_scene_id,
+        time_of_day=time_of_day,
         turn_count=0,
     )
     db.add(state)

--- a/backend/tavern/api/turns.py
+++ b/backend/tavern/api/turns.py
@@ -55,7 +55,11 @@ from tavern.core.dice import roll_d20
 from tavern.core.scene import normalise_scene_id
 from tavern.core.spells import resolve_spell
 from tavern.dm.context_builder import TurnContext, build_snapshot
-from tavern.dm.gm_signals import GMSignals, NPCUpdate, safe_default
+from tavern.dm.gm_signals import (
+    GMSignals,
+    NPCUpdate,
+    safe_default,
+)
 from tavern.dm.narrator import Narrator
 from tavern.dm.summary import build_turn_summary_input, trim_summary
 from tavern.models.campaign import Campaign, CampaignState
@@ -585,6 +589,10 @@ async def _process_npc_update(
     Performs name-based lookup (case-insensitive within campaign).
     Broadcasts npc.spawned or npc.updated via WebSocket.
     Does NOT commit — caller is responsible for the transaction boundary.
+
+    Spawned NPCs receive scene_location=NULL. The pipeline's post-signal
+    finalisation step (ADR-0019, Package C) assigns the final current_scene_id
+    to all NULL-location NPCs from this turn after location_change is processed.
     """
     from tavern.api.ws import manager
 
@@ -607,7 +615,11 @@ async def _process_npc_update(
             )
             return
 
-        # Create new NPC record
+        # Create new NPC record.
+        # scene_location is intentionally left NULL here (ADR-0019, Package C).
+        # After all signals are processed, any NULL-location NPCs from this turn
+        # are assigned the final current_scene_id in the post-signal finalisation
+        # step (handles both the no-location-change and location-change cases).
         npc = NPC(
             campaign_id=campaign_id,
             name=update.npc_name,
@@ -619,6 +631,7 @@ async def _process_npc_update(
             disposition=update.disposition or "unknown",
             hp_max=update.hp_max,
             ac=update.ac,
+            scene_location=None,
             first_appeared_turn=sequence_number,
             last_seen_turn=sequence_number,
         )
@@ -755,8 +768,12 @@ async def _stream_narrative(
     Pipeline:
     1. Narrate → (narrative_text, gm_signals)
     2. Broadcast narrative start / chunk / end events
-    3. Process gm_signals.npc_updates (within DB transaction)
-    4. Process gm_signals.scene_transition (Engine combat_end takes precedence)
+    3. (DB session) Process gm_signals in order per ADR-0019 §3:
+       a. npc_updates
+       b. location_change    ← ADR-0019: update current_scene_id; auto-assign NPC locations
+       c. time_progression   ← ADR-0019: update time_of_day
+       d. scene_transition   (Engine combat_end takes precedence)
+    4. Broadcast location_change and time_progression WebSocket events (after narrative_end)
     5. Persist turn narrative + gm_signals JSON + event_log
     6. Update rolling summary
 
@@ -890,6 +907,8 @@ async def _stream_narrative(
                 "fallback_used": gm_diag["fallback_used"],
                 "has_scene_transition": gm_signals.scene_transition.type != "none",
                 "npc_update_count": len(gm_signals.npc_updates),
+                "has_location_change": gm_signals.location_change is not None,
+                "has_time_progression": gm_signals.time_progression is not None,
                 "suggested_actions_count": len(gm_signals.suggested_actions),
             },
             decision=(
@@ -898,6 +917,8 @@ async def _stream_narrative(
                 else (
                     f"Parsed — transition={gm_signals.scene_transition.type}, "
                     f"npc_updates={len(gm_signals.npc_updates)}, "
+                    f"location_change={'yes' if gm_signals.location_change else 'no'}, "
+                    f"time_progression={'yes' if gm_signals.time_progression else 'no'}, "
                     f"suggested={len(gm_signals.suggested_actions)}"
                 )
             ),
@@ -916,43 +937,24 @@ async def _stream_narrative(
         },
     )
 
-    # Emit suggested actions immediately after narrative_end (ADR-0015)
-    logger.debug(
-        "GMSignals suggested_actions after parsing: %r (turn_id=%s)",
-        gm_signals.suggested_actions,
-        turn_id,
-    )
-    if gm_signals.suggested_actions:
-        await manager.broadcast(
-            campaign_id,
-            {
-                "event": "turn.suggested_actions",
-                "payload": {
-                    "turn_id": str(turn_id),
-                    "character_id": str(character_id),
-                    "suggestions": gm_signals.suggested_actions,
-                },
-            },
-        )
-
-    # suggested_actions_emit step
-    suggestion_count = len(gm_signals.suggested_actions)
-    acc.add_step(
-        PipelineStep(
-            step="suggested_actions_emit",
-            started_at=datetime.now(UTC),
-            duration_ms=0,
-            input_summary={"raw_count": suggestion_count},
-            output_summary={"emitted": suggestion_count},
-            decision=f"{suggestion_count} suggestions emitted",
-        )
-    )
+    # WebSocket events for location_change and time_progression are emitted
+    # after narrative_end and before suggested_actions (ADR-0019 §6).
+    # The DB handlers run inside the session block below; we capture the
+    # normalised values here so we can broadcast after the commit.
+    _ws_location_change: str | None = None
+    _ws_time_progression: str | None = None
 
     # Persist narrative and process GMSignals (own session)
     async with session_factory() as db:
         try:
+            # Re-load campaign state (may have been updated by request-phase combat start)
+            state_result = await db.execute(
+                select(CampaignState).where(CampaignState.campaign_id == campaign_id)
+            )
+            campaign_state = state_result.scalar_one_or_none()
+
             # -------------------------------------------------------------------
-            # Step A: Process npc_updates BEFORE scene_transition
+            # Step A: Process npc_updates BEFORE location_change (ADR-0019 §3)
             # -------------------------------------------------------------------
             npc_spawned = 0
             npc_updated = 0
@@ -990,17 +992,138 @@ async def _stream_narrative(
             )
 
             # -------------------------------------------------------------------
-            # Step B: Process scene_transition
+            # Step B: Process location_change (ADR-0019 §3, step 2)
+            # -------------------------------------------------------------------
+            if gm_signals.location_change is not None and campaign_state is not None:
+                lc_start = datetime.now(UTC)
+                lc_start_mono = time.monotonic()
+                try:
+                    new_scene_id = normalise_scene_id(gm_signals.location_change.new_location)
+                    campaign_state.current_scene_id = new_scene_id
+                    campaign_state.updated_at = datetime.now(tz=UTC)
+
+                    # Pre-assign scene_location for NPCs spawned this turn so
+                    # they immediately reflect the new location (ADR-0019 §3 step 2).
+                    # The C+ finalise step below will pick up any that remain NULL.
+                    null_loc_result = await db.execute(
+                        select(NPC).where(
+                            NPC.campaign_id == campaign_id,
+                            NPC.first_appeared_turn == sequence_number,
+                            NPC.scene_location.is_(None),
+                        )
+                    )
+                    auto_assigned = 0
+                    for npc_to_assign in null_loc_result.scalars().all():
+                        npc_to_assign.scene_location = new_scene_id
+                        auto_assigned += 1
+
+                    await db.flush()
+                    _ws_location_change = new_scene_id
+                    lc_duration_ms = int((time.monotonic() - lc_start_mono) * 1000)
+                    acc.add_step(
+                        PipelineStep(
+                            step="location_change_apply",
+                            started_at=lc_start,
+                            duration_ms=lc_duration_ms,
+                            input_summary={
+                                "raw_location": gm_signals.location_change.new_location,
+                            },
+                            output_summary={
+                                "new_scene_id": new_scene_id,
+                                "npcs_auto_assigned": auto_assigned,
+                            },
+                            decision=(
+                                gm_signals.location_change.reason or f"Location → {new_scene_id}"
+                            ),
+                        )
+                    )
+                    logger.info(
+                        "Location changed to %r for campaign %s (%d NPCs auto-assigned)",
+                        new_scene_id,
+                        campaign_id,
+                        auto_assigned,
+                    )
+                except ValueError as exc:
+                    lc_duration_ms = int((time.monotonic() - lc_start_mono) * 1000)
+                    acc.add_warning(f"location_change rejected — invalid scene identifier: {exc}")
+                    acc.add_step(
+                        PipelineStep(
+                            step="location_change_apply",
+                            started_at=lc_start,
+                            duration_ms=lc_duration_ms,
+                            input_summary={
+                                "raw_location": gm_signals.location_change.new_location,
+                            },
+                            output_summary={"rejected": True},
+                            decision=f"Rejected — {exc}",
+                        )
+                    )
+                    logger.error(
+                        "location_change for campaign %s rejected — invalid scene identifier: %s",
+                        campaign_id,
+                        exc,
+                    )
+
+            # -------------------------------------------------------------------
+            # Step C: Process time_progression (ADR-0019 §3, step 3)
+            # -------------------------------------------------------------------
+            if gm_signals.time_progression is not None and campaign_state is not None:
+                tp_start = datetime.now(UTC)
+                tp_start_mono = time.monotonic()
+                campaign_state.time_of_day = gm_signals.time_progression.new_time_of_day
+                campaign_state.updated_at = datetime.now(tz=UTC)
+                await db.flush()
+                _ws_time_progression = gm_signals.time_progression.new_time_of_day
+                tp_duration_ms = int((time.monotonic() - tp_start_mono) * 1000)
+                acc.add_step(
+                    PipelineStep(
+                        step="time_progression_apply",
+                        started_at=tp_start,
+                        duration_ms=tp_duration_ms,
+                        input_summary={
+                            "new_time_of_day": gm_signals.time_progression.new_time_of_day,
+                        },
+                        output_summary={
+                            "time_of_day": gm_signals.time_progression.new_time_of_day,
+                        },
+                        decision=(
+                            gm_signals.time_progression.reason
+                            or f"Time → {gm_signals.time_progression.new_time_of_day}"
+                        ),
+                    )
+                )
+                logger.info(
+                    "Time of day advanced to %r for campaign %s",
+                    gm_signals.time_progression.new_time_of_day,
+                    campaign_id,
+                )
+
+            # -------------------------------------------------------------------
+            # Step C+: Finalise NPC scene_location for NPCs spawned this turn
+            # (ADR-0019, Package C).  Any NPCs spawned in step A that still
+            # have scene_location = NULL are assigned the final current_scene_id
+            # (which may have been updated by the location_change handler above).
+            # -------------------------------------------------------------------
+            if campaign_state is not None and npc_spawned > 0:
+                final_scene_id = campaign_state.current_scene_id
+                if final_scene_id:
+                    null_loc_result = await db.execute(
+                        select(NPC).where(
+                            NPC.campaign_id == campaign_id,
+                            NPC.first_appeared_turn == sequence_number,
+                            NPC.scene_location.is_(None),
+                        )
+                    )
+                    for npc_to_finalise in null_loc_result.scalars().all():
+                        npc_to_finalise.scene_location = final_scene_id
+                    await db.flush()
+
+            # -------------------------------------------------------------------
+            # Step D: Process scene_transition (ADR-0019 §3, step 4)
             # -------------------------------------------------------------------
             current_mode = str(world_state.get("mode", "exploration"))
 
-            # Re-load campaign state to get latest world_state (may have been
-            # updated by the request-phase combat start)
-            state_result = await db.execute(
-                select(CampaignState).where(CampaignState.campaign_id == campaign_id)
-            )
-            campaign_state = state_result.scalar_one_or_none()
-
+            # campaign_state was loaded at the top of this block.
             # Check whether the Rules Engine ended combat (all NPCs at 0 HP).
             # For M1 we detect this via the world_state "engine_combat_end" flag
             # that submit_turn may have set.  If not set, we rely on Narrator signals.
@@ -1236,6 +1359,66 @@ async def _stream_narrative(
         except Exception as exc:
             logger.error("DB persist failed for turn %s: %s", turn_id, exc)
             return
+
+    # Emit location_change and time_progression events after narrative_end,
+    # before suggested_actions (ADR-0019 §6 emission sequence)
+    if _ws_location_change is not None:
+        await manager.broadcast(
+            campaign_id,
+            {
+                "event": "turn.location_change",
+                "payload": {
+                    "turn_id": str(turn_id),
+                    "campaign_id": str(campaign_id),
+                    "new_location": _ws_location_change,
+                },
+            },
+        )
+
+    if _ws_time_progression is not None:
+        await manager.broadcast(
+            campaign_id,
+            {
+                "event": "turn.time_progression",
+                "payload": {
+                    "turn_id": str(turn_id),
+                    "campaign_id": str(campaign_id),
+                    "new_time_of_day": _ws_time_progression,
+                },
+            },
+        )
+
+    # Emit suggested actions after location/time events (ADR-0019 §6, ADR-0015)
+    logger.debug(
+        "GMSignals suggested_actions after parsing: %r (turn_id=%s)",
+        gm_signals.suggested_actions,
+        turn_id,
+    )
+    if gm_signals.suggested_actions:
+        await manager.broadcast(
+            campaign_id,
+            {
+                "event": "turn.suggested_actions",
+                "payload": {
+                    "turn_id": str(turn_id),
+                    "character_id": str(character_id),
+                    "suggestions": gm_signals.suggested_actions,
+                },
+            },
+        )
+
+    # suggested_actions_emit step
+    suggestion_count = len(gm_signals.suggested_actions)
+    acc.add_step(
+        PipelineStep(
+            step="suggested_actions_emit",
+            started_at=datetime.now(UTC),
+            duration_ms=0,
+            input_summary={"raw_count": suggestion_count},
+            output_summary={"emitted": suggestion_count},
+            decision=f"{suggestion_count} suggestions emitted",
+        )
+    )
 
     # Emit turn.event_log WebSocket event (after DB commit)
     pipeline_duration_ms = int(

--- a/backend/tavern/dm/context_builder.py
+++ b/backend/tavern/dm/context_builder.py
@@ -301,21 +301,21 @@ def _build_scene_context(state: CampaignState) -> SceneContext:
     """Extract SceneContext from CampaignState.
 
     ``scene_context`` (Text column) holds the 2-3 sentence location description.
-    Structured scene fields are read from ``world_state`` (JSONB):
-      - location     (str)
+    ``current_scene_id`` (Text column) is the authoritative party location (ADR-0019).
+    ``time_of_day`` (String column) is the authoritative time of day (ADR-0019).
+    Remaining scene fields are read from ``world_state`` (JSONB):
       - npcs         (list[str])
       - environment  (str)
       - threats      (list[str])
-      - time_of_day  (str)
     """
     ws = state.world_state or {}
     return SceneContext(
-        location=str(ws.get("location", "Unknown location")),
+        location=state.current_scene_id or str(ws.get("location", "unknown")),
         description=state.scene_context.strip(),
         npcs=list(ws.get("npcs", [])),
         environment=str(ws.get("environment", "")),
         threats=list(ws.get("threats", [])),
-        time_of_day=str(ws.get("time_of_day", "")),
+        time_of_day=state.time_of_day or str(ws.get("time_of_day", "morning")),
     )
 
 
@@ -370,7 +370,10 @@ async def build_snapshot(
     # Query NPCs relevant to the current scene / recent turns (ADR-0013)
     current_turn_number = campaign.state.turn_count
     recency_threshold = max(0, current_turn_number - 10)
-    scene_location = str((campaign.state.world_state or {}).get("location", ""))
+    # Use current_scene_id (ADR-0019) as the authoritative location for NPC scoping
+    scene_location = campaign.state.current_scene_id or str(
+        (campaign.state.world_state or {}).get("location", "")  # DEPRECATED: ADR-0019 fallback
+    )
 
     npc_result = await db_session.execute(
         select(NPC)
@@ -505,12 +508,21 @@ def _serialize_character(char: CharacterState) -> str:
 
 
 def _serialize_scene(scene: SceneContext) -> str:
-    """Render the scene context as plain text."""
-    parts: list[str] = [f"Location: {scene.location}"]
+    """Render the scene context as plain text.
+
+    Format (ADR-0019 §5):
+      Scene: <current_scene_id>   — normalised identifier; Narrator references this in
+                                    location_change signals
+      Time: <time_of_day>         — always present
+      <description prose>
+      Environment: ...
+      ...
+    """
+    parts: list[str] = [f"Scene: {scene.location}"]
+    # Time is always present so the Narrator has reliable context (ADR-0019 §5)
+    parts.append(f"Time: {scene.time_of_day or 'morning'}")
     if scene.description:
         parts.append(scene.description)
-    if scene.time_of_day:
-        parts.append(f"Time: {scene.time_of_day}")
     if scene.environment:
         parts.append(f"Environment: {scene.environment}")
     if scene.npcs:

--- a/backend/tavern/dm/gm_signals.py
+++ b/backend/tavern/dm/gm_signals.py
@@ -7,6 +7,7 @@ broadcasting narrative text to clients.
 
 ADR-0012: NPC-initiated combat
 ADR-0013: NPC lifecycle
+ADR-0019: Exploration state signals (LocationChange, TimeProgression)
 """
 
 from __future__ import annotations
@@ -69,6 +70,33 @@ class NPCUpdate:
     new_location: str | None = None
 
 
+_VALID_TIMES_OF_DAY = frozenset(
+    {"dawn", "morning", "midday", "afternoon", "dusk", "evening", "night", "late_night"}
+)
+
+
+@dataclass
+class LocationChange:
+    """An exploration-mode party location change signalled by the Narrator (ADR-0019)."""
+
+    new_location: str
+    """Raw location identifier; normalised via normalise_scene_id() before write."""
+
+    reason: str = ""
+    """One sentence for logging — never player-facing."""
+
+
+@dataclass
+class TimeProgression:
+    """A time-of-day advancement signalled by the Narrator (ADR-0019)."""
+
+    new_time_of_day: Literal[
+        "dawn", "morning", "midday", "afternoon", "dusk", "evening", "night", "late_night"
+    ]
+    reason: str = ""
+    """One sentence for logging — never player-facing."""
+
+
 @dataclass
 class GMSignals:
     """Complete GM signal envelope appended to every Narrator response."""
@@ -77,6 +105,10 @@ class GMSignals:
     npc_updates: list[NPCUpdate] = field(default_factory=list)
     suggested_actions: list[str] = field(default_factory=list)
     """0–3 narrative action suggestions for the active player (ADR-0015)."""
+    location_change: LocationChange | None = None
+    """Party location change signal (ADR-0019). None means no location change this turn."""
+    time_progression: TimeProgression | None = None
+    """Time-of-day advancement signal (ADR-0019). None means no time change this turn."""
 
 
 # ---------------------------------------------------------------------------
@@ -280,10 +312,63 @@ def parse_gm_signals(raw: str) -> tuple[GMSignals, dict]:
             continue
         suggested_actions.append(item[:_MAX_SUGGESTION_LEN])
 
+    # --- Parse location_change (ADR-0019) ---
+    location_change: LocationChange | None = None
+    lc_raw = data.get("location_change")
+    if lc_raw is not None:
+        if not isinstance(lc_raw, dict):
+            logger.warning(
+                "GMSignals location_change is not an object — ignoring. value=%r", lc_raw
+            )
+        else:
+            new_loc = lc_raw.get("new_location")
+            if not new_loc or not isinstance(new_loc, str):
+                logger.warning(
+                    "GMSignals location_change.new_location missing or not a string — "
+                    "ignoring. value=%r",
+                    new_loc,
+                )
+            else:
+                location_change = LocationChange(
+                    new_location=new_loc,
+                    reason=str(lc_raw.get("reason", "")),
+                )
+
+    # --- Parse time_progression (ADR-0019) ---
+    time_progression: TimeProgression | None = None
+    tp_raw = data.get("time_progression")
+    if tp_raw is not None:
+        if not isinstance(tp_raw, dict):
+            logger.warning(
+                "GMSignals time_progression is not an object — ignoring. value=%r", tp_raw
+            )
+        else:
+            new_time = tp_raw.get("new_time_of_day")
+            if not new_time or not isinstance(new_time, str):
+                logger.warning(
+                    "GMSignals time_progression.new_time_of_day missing or not a string — "
+                    "ignoring. value=%r",
+                    new_time,
+                )
+            elif new_time not in _VALID_TIMES_OF_DAY:
+                logger.warning(
+                    "GMSignals time_progression.new_time_of_day invalid value %r — "
+                    "ignoring. Valid values: %s",
+                    new_time,
+                    ", ".join(sorted(_VALID_TIMES_OF_DAY)),
+                )
+            else:
+                time_progression = TimeProgression(
+                    new_time_of_day=new_time,  # type: ignore[arg-type]
+                    reason=str(tp_raw.get("reason", "")),
+                )
+
     return _success(
         GMSignals(
             scene_transition=scene_transition,
             npc_updates=npc_updates,
             suggested_actions=suggested_actions,
+            location_change=location_change,
+            time_progression=time_progression,
         )
     )

--- a/backend/tavern/dm/narrator.py
+++ b/backend/tavern/dm/narrator.py
@@ -92,9 +92,9 @@ def _estimate_cost(
 
 
 # GMSignals instruction appended to the system prompt for every narration
-# request (ADR-0012, ADR-0013).  The model MUST append the delimiter line and
-# JSON block after every narrative response so the turn pipeline can extract
-# structured signals without player-facing text being contaminated.
+# request (ADR-0012, ADR-0013, ADR-0019).  The model MUST append the delimiter
+# line and JSON block after every narrative response so the turn pipeline can
+# extract structured signals without player-facing text being contaminated.
 _GM_SIGNALS_INSTRUCTION = (
     "\n\nAfter your narrative response, you MUST always append a GMSignals block "
     "on a new line. The delimiter must appear on its own line with no leading or "
@@ -104,6 +104,7 @@ _GM_SIGNALS_INSTRUCTION = (
     f"{GM_SIGNALS_DELIMITER}\n"
     '{"scene_transition": {"type": "none", "combatants": [], '
     '"potential_surprised_characters": [], "reason": ""}, "npc_updates": [], '
+    '"location_change": null, "time_progression": null, '
     '"suggested_actions": ["Slip through the gap before the guards arrive", '
     '"Demand the harbormaster explain herself"]}\n\n'
     'Rules for scene_transition.type: must be exactly "none", "combat_start", or '
@@ -111,9 +112,59 @@ _GM_SIGNALS_INSTRUCTION = (
     'Use "combat_end" only when all hostile NPCs are defeated or fled. '
     '"npc_updates" must be a list (may be empty). Each entry needs "event" '
     '(spawn|status_change|disposition_change|location_change) and "npc_name". '
+    '"location_change" is an object with "new_location" (snake_case identifier) and '
+    'optional "reason", or null if the party has not changed location this turn. '
+    '"time_progression" is an object with "new_time_of_day" and optional "reason", '
+    "or null if time has not advanced this turn. "
     '"suggested_actions" must be a JSON array of 0–3 first-person action phrases '
     "(5–12 words each). Default to 2 suggestions. See earlier instructions for "
-    "full rules. Always include all three top-level keys."
+    "full rules. Always include all five top-level keys."
+)
+
+# Location change behavioral instructions (ADR-0019).
+_LOCATION_CHANGE_INSTRUCTIONS = (
+    "\n\nLOCATION CHANGE RULES:\n"
+    "When the party moves to a new location — entering a building, leaving a town,\n"
+    "descending into a dungeon, traveling to a new area — emit a location_change in\n"
+    "your GMSignals block.\n"
+    "\n"
+    "The new_location value must be a snake_case identifier: lowercase letters, digits,\n"
+    "and underscores only. Use the same identifier consistently for the same physical\n"
+    "location. Examples: harborside_supply, the_drowned_anchor, dungeon_level_2.\n"
+    "\n"
+    "Emit location_change only when the party's physical location changes. Do not emit\n"
+    "it for movement within the same location (walking across a tavern, moving to a\n"
+    "different table).\n"
+    "\n"
+    "If the party returns to a previously visited location, reuse the same identifier.\n"
+    "Your current location is shown in the Scene: field of your context — reference it\n"
+    "if you are unsure what identifier to use for the current location.\n"
+    "\n"
+    "When location_change is null, the party's location is unchanged."
+)
+
+# Time progression behavioral instructions (ADR-0019).
+_TIME_PROGRESSION_INSTRUCTIONS = (
+    "\n\nTIME PROGRESSION RULES:\n"
+    "When significant time passes in the narrative — hours of travel, waiting until\n"
+    "nightfall, the passage of an afternoon — emit a time_progression in your GMSignals\n"
+    "block.\n"
+    "\n"
+    "The new_time_of_day value must be one of exactly eight values:\n"
+    "  dawn, morning, midday, afternoon, dusk, evening, night, late_night\n"
+    "\n"
+    "Your current time of day is shown in the Time: field of your context. Advance time\n"
+    "consistently: if it is currently morning and the party travels for several hours,\n"
+    "the new time should be midday or afternoon, not night.\n"
+    "\n"
+    "Do not emit time_progression on every turn. Most turns occur within a single time\n"
+    "period. Emit it only when the narrative describes meaningful time passing.\n"
+    "\n"
+    "Do not emit time_progression for Short Rests or Long Rests — those are mechanical\n"
+    "events handled by the Rules Engine. Only emit it for narrative time passage outside\n"
+    "of rest mechanics.\n"
+    "\n"
+    "When time_progression is null, the time of day is unchanged."
 )
 
 # NPC lifecycle behavioral instructions appended to the system prompt (ADR-0013).
@@ -303,8 +354,14 @@ class AnthropicProvider:
         self._client = anthropic.AsyncAnthropic(api_key=api_key)
 
     def _build_system_with_signals(self, system_text: str) -> str:
-        """Append the GMSignals and NPC consistency instructions to the system prompt."""
-        return system_text + _GM_SIGNALS_INSTRUCTION + _NPC_CONSISTENCY_INSTRUCTION
+        """Append the GMSignals, NPC consistency, and exploration state instructions."""
+        return (
+            system_text
+            + _GM_SIGNALS_INSTRUCTION
+            + _NPC_CONSISTENCY_INSTRUCTION
+            + _LOCATION_CHANGE_INSTRUCTIONS
+            + _TIME_PROGRESSION_INSTRUCTIONS
+        )
 
     async def narrate(
         self,

--- a/backend/tavern/models/campaign.py
+++ b/backend/tavern/models/campaign.py
@@ -48,12 +48,25 @@ class Campaign(Base):
 
 class CampaignState(Base):
     __tablename__ = "campaign_states"
+    _VALID_TIMES = (
+        "'dawn', 'morning', 'midday', 'afternoon', 'dusk', 'evening', 'night', 'late_night'"
+    )
+    __table_args__ = (
+        CheckConstraint(
+            f"time_of_day IN ({_VALID_TIMES})",
+            name="ck_campaign_states_time_of_day",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     campaign_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("campaigns.id"), unique=True)
     rolling_summary: Mapped[str] = mapped_column(Text)
     scene_context: Mapped[str] = mapped_column(Text)
     world_state: Mapped[dict] = mapped_column(JSONB)
+    current_scene_id: Mapped[str] = mapped_column(Text, default="")
+    """Normalised scene identifier for the party's current location (ADR-0019)."""
+    time_of_day: Mapped[str] = mapped_column(String, default="morning")
+    """Current time of day — one of the eight enumerated values (ADR-0019)."""
     turn_count: Mapped[int] = mapped_column(default=0)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/tavern/tests/api/test_turn_lifecycle.py
+++ b/backend/tavern/tests/api/test_turn_lifecycle.py
@@ -27,8 +27,10 @@ from tavern.dm.combat_classifier import CombatClassification
 from tavern.dm.gm_signals import (
     GM_SIGNALS_DELIMITER,
     GMSignals,
+    LocationChange,
     NPCUpdate,
     SceneTransition,
+    TimeProgression,
     parse_gm_signals,
     safe_default,
 )
@@ -64,12 +66,13 @@ def _campaign_state(campaign_id: uuid.UUID, mode: str = "exploration") -> Campai
         scene_context="A dimly lit crossroads.",
         world_state={
             "location": "Forest Crossroads",
-            "time_of_day": "dusk",
             "environment": "misty",
             "npcs": [],
             "threats": [],
             "mode": mode,
         },
+        current_scene_id="forest_crossroads",
+        time_of_day="dusk",
         turn_count=0,
     )
 
@@ -660,3 +663,388 @@ class TestNarrativeTextClean:
             assert GM_SIGNALS_DELIMITER not in narrative, (
                 f"narrative_text must not contain GMSignals delimiter: {narrative!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# ADR-0019: location_change signal processing
+# ---------------------------------------------------------------------------
+
+
+class TestLocationChangeSignal:
+    async def test_location_change_updates_current_scene_id(self, api_client: AsyncClient) -> None:
+        """A location_change signal updates CampaignState.current_scene_id."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "Location Change Test")
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[],
+            location_change=LocationChange(
+                new_location="harborside_supply",
+                reason="Player entered the shop",
+            ),
+        )
+        mock_narrator = _make_mock_narrator(
+            narrative="You step into Harborside Supply.",
+            gm_signals=signals,
+        )
+
+        broadcast_events: list[dict] = []
+
+        async def capture(campaign_id_arg, event):  # type: ignore[no-untyped-def]
+            broadcast_events.append(event)
+
+        original_broadcast = ws_mod.manager.broadcast
+        ws_mod.manager.broadcast = AsyncMock(side_effect=capture)
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                resp = await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "I walk into the shop."},
+                )
+        finally:
+            ws_mod.manager.broadcast = original_broadcast
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        assert resp.status_code == 202
+
+        async with _TEST_SESSION_FACTORY() as db:
+            state_result = await db.execute(
+                select(CampaignState).where(CampaignState.campaign_id == uuid.UUID(cid))
+            )
+            state = state_result.scalar_one_or_none()
+            assert state is not None
+            assert state.current_scene_id == "harborside_supply"
+
+    async def test_location_change_emits_websocket_event(self, api_client: AsyncClient) -> None:
+        """A location_change signal causes a turn.location_change WebSocket event."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "Location WS Test")
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[],
+            location_change=LocationChange(new_location="dungeon_entrance"),
+        )
+        mock_narrator = _make_mock_narrator(
+            narrative="You descend into the dungeon.",
+            gm_signals=signals,
+        )
+
+        broadcast_events: list[dict] = []
+
+        async def capture(campaign_id_arg, event):  # type: ignore[no-untyped-def]
+            broadcast_events.append(event)
+
+        original_broadcast = ws_mod.manager.broadcast
+        ws_mod.manager.broadcast = AsyncMock(side_effect=capture)
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                resp = await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "I descend."},
+                )
+        finally:
+            ws_mod.manager.broadcast = original_broadcast
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        assert resp.status_code == 202
+
+        lc_events = [e for e in broadcast_events if e.get("event") == "turn.location_change"]
+        assert len(lc_events) == 1
+        assert lc_events[0]["payload"]["new_location"] == "dungeon_entrance"
+
+    async def test_location_change_normalises_raw_identifier(
+        self, api_client: AsyncClient
+    ) -> None:
+        """Raw location identifiers with spaces/capitals are normalised before write."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "Normalise Test")
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[],
+            location_change=LocationChange(new_location="Harborside Supply"),
+        )
+        mock_narrator = _make_mock_narrator(gm_signals=signals)
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "I enter."},
+                )
+        finally:
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        async with _TEST_SESSION_FACTORY() as db:
+            state_result = await db.execute(
+                select(CampaignState).where(CampaignState.campaign_id == uuid.UUID(cid))
+            )
+            state = state_result.scalar_one_or_none()
+            assert state is not None
+            assert state.current_scene_id == "harborside_supply"
+
+    async def test_location_change_after_narrative_end_before_suggested_actions(
+        self, api_client: AsyncClient
+    ) -> None:
+        """turn.location_change event is emitted after narrative_end, before suggested_actions."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "Event Order Test")
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[],
+            location_change=LocationChange(new_location="new_place"),
+            suggested_actions=["Look around"],
+        )
+        mock_narrator = _make_mock_narrator(gm_signals=signals)
+
+        broadcast_events: list[dict] = []
+
+        async def capture(campaign_id_arg, event):  # type: ignore[no-untyped-def]
+            broadcast_events.append(event)
+
+        original_broadcast = ws_mod.manager.broadcast
+        ws_mod.manager.broadcast = AsyncMock(side_effect=capture)
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                resp = await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "I move."},
+                )
+        finally:
+            ws_mod.manager.broadcast = original_broadcast
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        assert resp.status_code == 202
+
+        event_names = [e.get("event") or e.get("type") for e in broadcast_events]
+        narrative_end_idx = next(
+            (i for i, n in enumerate(event_names) if n == "turn.narrative_end"), None
+        )
+        location_change_idx = next(
+            (i for i, n in enumerate(event_names) if n == "turn.location_change"), None
+        )
+        suggested_idx = next(
+            (i for i, n in enumerate(event_names) if n == "turn.suggested_actions"), None
+        )
+        assert narrative_end_idx is not None
+        assert location_change_idx is not None
+        assert suggested_idx is not None
+        assert narrative_end_idx < location_change_idx < suggested_idx
+
+
+# ---------------------------------------------------------------------------
+# ADR-0019: time_progression signal processing
+# ---------------------------------------------------------------------------
+
+
+class TestTimeProgressionSignal:
+    async def test_time_progression_updates_time_of_day(self, api_client: AsyncClient) -> None:
+        """A time_progression signal updates CampaignState.time_of_day."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "Time Progression Test")
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[],
+            time_progression=TimeProgression(
+                new_time_of_day="evening",
+                reason="Hours of travel",
+            ),
+        )
+        mock_narrator = _make_mock_narrator(
+            narrative="The sun dips below the horizon.",
+            gm_signals=signals,
+        )
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                resp = await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "We travel."},
+                )
+        finally:
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        assert resp.status_code == 202
+
+        async with _TEST_SESSION_FACTORY() as db:
+            state_result = await db.execute(
+                select(CampaignState).where(CampaignState.campaign_id == uuid.UUID(cid))
+            )
+            state = state_result.scalar_one_or_none()
+            assert state is not None
+            assert state.time_of_day == "evening"
+
+    async def test_time_progression_emits_websocket_event(self, api_client: AsyncClient) -> None:
+        """A time_progression signal causes a turn.time_progression WebSocket event."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "Time WS Test")
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[],
+            time_progression=TimeProgression(new_time_of_day="night"),
+        )
+        mock_narrator = _make_mock_narrator(gm_signals=signals)
+
+        broadcast_events: list[dict] = []
+
+        async def capture(campaign_id_arg, event):  # type: ignore[no-untyped-def]
+            broadcast_events.append(event)
+
+        original_broadcast = ws_mod.manager.broadcast
+        ws_mod.manager.broadcast = AsyncMock(side_effect=capture)
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                resp = await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "Night falls."},
+                )
+        finally:
+            ws_mod.manager.broadcast = original_broadcast
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        assert resp.status_code == 202
+
+        tp_events = [e for e in broadcast_events if e.get("event") == "turn.time_progression"]
+        assert len(tp_events) == 1
+        assert tp_events[0]["payload"]["new_time_of_day"] == "night"
+
+
+# ---------------------------------------------------------------------------
+# ADR-0019: NPC spawn location auto-assignment (Package C)
+# ---------------------------------------------------------------------------
+
+
+class TestNPCSpawnLocationAutoAssign:
+    async def test_spawned_npc_gets_current_scene_id(self, api_client: AsyncClient) -> None:
+        """Spawned NPC without explicit location gets scene_location = current_scene_id."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "NPC Spawn Location Test")
+
+        # Set the campaign's current_scene_id before the turn
+        async with _TEST_SESSION_FACTORY() as db:
+            state_result = await db.execute(
+                select(CampaignState).where(CampaignState.campaign_id == uuid.UUID(cid))
+            )
+            state = state_result.scalar_one_or_none()
+            if state is not None:
+                state.current_scene_id = "harborside_supply"
+                await db.commit()
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[
+                NPCUpdate(
+                    event="spawn",
+                    npc_name="Vara",
+                    species="Human",
+                    appearance="A woman with sun-darkened skin.",
+                    role="Shopkeeper",
+                    motivation="To earn a living",
+                    disposition="neutral",
+                )
+            ],
+        )
+        mock_narrator = _make_mock_narrator(gm_signals=signals)
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                resp = await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "I enter the shop."},
+                )
+        finally:
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        assert resp.status_code == 202
+
+        async with _TEST_SESSION_FACTORY() as db:
+            npc_result = await db.execute(
+                select(NPC).where(
+                    NPC.campaign_id == uuid.UUID(cid),
+                    NPC.name == "Vara",
+                )
+            )
+            vara = npc_result.scalar_one_or_none()
+            assert vara is not None
+            assert vara.scene_location == "harborside_supply"
+
+    async def test_spawn_plus_location_change_auto_assigns_new_scene(
+        self, api_client: AsyncClient
+    ) -> None:
+        """When spawn + location_change fire on same turn, NPC gets the new location."""
+        cid, char_id = await _setup_campaign_with_char(api_client, "Spawn+Location Test")
+
+        signals = GMSignals(
+            scene_transition=SceneTransition(type="none"),
+            npc_updates=[
+                NPCUpdate(
+                    event="spawn",
+                    npc_name="Dock Master",
+                    species="Human",
+                    appearance="A grizzled man with a pipe.",
+                    role="Dock Master",
+                    motivation="Keep the docks running",
+                    disposition="neutral",
+                )
+            ],
+            location_change=LocationChange(new_location="dock_district"),
+        )
+        mock_narrator = _make_mock_narrator(gm_signals=signals)
+
+        try:
+            with patch(
+                "tavern.dm.combat_classifier.CombatClassifier.classify",
+                new=AsyncMock(return_value=_no_combat_classification()),
+            ):
+                app.dependency_overrides[get_narrator_dep] = lambda: mock_narrator
+                resp = await api_client.post(
+                    f"/api/campaigns/{cid}/turns",
+                    json={"character_id": char_id, "action": "I head to the docks."},
+                )
+        finally:
+            app.dependency_overrides.pop(get_narrator_dep, None)
+
+        assert resp.status_code == 202
+
+        async with _TEST_SESSION_FACTORY() as db:
+            npc_result = await db.execute(
+                select(NPC).where(
+                    NPC.campaign_id == uuid.UUID(cid),
+                    NPC.name == "Dock Master",
+                )
+            )
+            npc = npc_result.scalar_one_or_none()
+            assert npc is not None
+            # NPC was spawned before location_change processed; auto-assignment
+            # sets scene_location to the new current_scene_id
+            assert npc.scene_location == "dock_district"

--- a/backend/tavern/tests/dm/test_context_builder.py
+++ b/backend/tavern/tests/dm/test_context_builder.py
@@ -53,10 +53,11 @@ def _campaign_state(
     rolling_summary: str = "The party has just arrived in Phandalin.",
     scene_context: str = "You stand in the dusty main street of Phandalin.",
     world_state: dict | None = None,
+    current_scene_id: str = "phandalin",
+    time_of_day: str = "midday",
 ) -> CampaignState:
     ws = world_state or {
         "location": "Phandalin",
-        "time_of_day": "midday",
         "environment": "sunny",
         "npcs": ["Gundren Rockseeker — friendly"],
         "threats": [],
@@ -67,6 +68,8 @@ def _campaign_state(
         rolling_summary=rolling_summary,
         scene_context=scene_context,
         world_state=ws,
+        current_scene_id=current_scene_id,
+        time_of_day=time_of_day,
         turn_count=1,
     )
 
@@ -260,13 +263,15 @@ class TestBuildSnapshot:
         assert snapshot.scene.description == state.scene_context.strip()
 
     async def test_snapshot_loads_scene_world_state_fields(self, db_session: AsyncSession) -> None:
-        """Scene context fields are read from world_state JSONB."""
+        """Scene location from current_scene_id column (ADR-0019)."""
         campaign, state, _ = await _populate_basic(db_session)
         turn = TurnContext(player_action="I look around.", rules_result=None)
 
         snapshot = await build_snapshot(campaign.id, turn, db_session)
 
-        assert snapshot.scene.location == "Phandalin"
+        # location now reads from current_scene_id column (ADR-0019)
+        assert snapshot.scene.location == "phandalin"
+        # time_of_day now reads from time_of_day column (ADR-0019)
         assert snapshot.scene.time_of_day == "midday"
         assert snapshot.scene.environment == "sunny"
         assert "Gundren Rockseeker — friendly" in snapshot.scene.npcs
@@ -534,14 +539,14 @@ class TestBuildSnapshot:
         assert "Distant Guard" not in npc_names
 
     async def test_snapshot_includes_npc_in_current_scene(self, db_session: AsyncSession) -> None:
-        """NPC whose scene_location matches the current scene is included."""
+        """NPC whose scene_location matches current_scene_id is included (ADR-0019)."""
         campaign, _, _ = await _populate_basic(db_session)
-        # _populate_basic sets world_state location to "Phandalin"
+        # _populate_basic sets current_scene_id to "phandalin" (normalised)
         npc = _npc(
             campaign.id,
             "Local Merchant",
             origin="narrator_spawned",
-            scene_location="Phandalin",
+            scene_location="phandalin",
         )
         db_session.add(npc)
         await db_session.commit()
@@ -630,12 +635,21 @@ class TestSerializeSnapshot:
         content = messages[0]["content"]
         assert "Aldric" in content
 
-    def test_user_message_contains_location(self) -> None:
+    def test_user_message_contains_scene_identifier(self) -> None:
+        """Scene field uses 'Scene:' label (ADR-0019 §5)."""
         result = serialize_snapshot(self._minimal_snapshot())
         messages = result["messages"]
         assert isinstance(messages, list)
         content = messages[0]["content"]
-        assert "Phandalin" in content
+        assert "Scene: Phandalin" in content
+
+    def test_user_message_contains_time_field(self) -> None:
+        """Time field is always present in the scene block (ADR-0019 §5)."""
+        result = serialize_snapshot(self._minimal_snapshot())
+        messages = result["messages"]
+        assert isinstance(messages, list)
+        content = messages[0]["content"]
+        assert "Time: noon" in content
 
     def test_user_message_contains_rolling_summary(self) -> None:
         result = serialize_snapshot(self._minimal_snapshot())
@@ -670,10 +684,10 @@ class TestSerializeSnapshot:
         assert isinstance(messages, list)
         content = messages[0]["content"]
         char_pos = content.index("Aldric")
-        location_pos = content.index("Phandalin")
+        scene_pos = content.index("Scene: Phandalin")
         summary_pos = content.index("The party arrived")
         action_pos = content.index("I look around the town")
-        assert char_pos < location_pos < summary_pos < action_pos
+        assert char_pos < scene_pos < summary_pos < action_pos
 
     def test_no_markdown_in_user_message(self) -> None:
         """ADR-0002: Plain text output — no Markdown formatting in the prompt."""
@@ -718,3 +732,126 @@ class TestSerializeSnapshot:
         assert isinstance(messages, list)
         content = messages[0]["content"]
         assert "Rules Engine result" not in content
+
+    def test_scene_label_not_location_label(self) -> None:
+        """ADR-0019 §5: serialised scene block uses 'Scene:' not 'Location:'."""
+        result = serialize_snapshot(self._minimal_snapshot())
+        messages = result["messages"]
+        assert isinstance(messages, list)
+        content = messages[0]["content"]
+        assert "Scene:" in content
+        assert "Location:" not in content
+
+    def test_time_always_present_even_empty(self) -> None:
+        """ADR-0019 §5: Time field is always included, defaulting to 'morning'."""
+        snapshot = self._minimal_snapshot()
+        snapshot.scene.time_of_day = ""
+        result = serialize_snapshot(snapshot)
+        messages = result["messages"]
+        assert isinstance(messages, list)
+        content = messages[0]["content"]
+        assert "Time: morning" in content
+
+
+# ---------------------------------------------------------------------------
+# ADR-0019: current_scene_id and time_of_day columns in build_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSnapshotADR0019:
+    async def test_snapshot_location_reads_current_scene_id_column(
+        self, db_session: AsyncSession
+    ) -> None:
+        """scene.location comes from CampaignState.current_scene_id column (ADR-0019)."""
+        campaign = _campaign()
+        db_session.add(campaign)
+        await db_session.flush()
+        state = _campaign_state(
+            campaign.id,
+            current_scene_id="harborside_supply",
+            world_state={"location": "Old Tavern", "environment": ""},
+        )
+        db_session.add(state)
+        db_session.add(_character(campaign.id))
+        await db_session.commit()
+
+        turn = TurnContext(player_action="Look around.", rules_result=None)
+        snapshot = await build_snapshot(campaign.id, turn, db_session)
+
+        assert snapshot.scene.location == "harborside_supply"
+
+    async def test_snapshot_time_reads_time_of_day_column(self, db_session: AsyncSession) -> None:
+        """scene.time_of_day comes from CampaignState.time_of_day column (ADR-0019)."""
+        campaign = _campaign()
+        db_session.add(campaign)
+        await db_session.flush()
+        state = _campaign_state(
+            campaign.id,
+            time_of_day="dusk",
+            world_state={"location": "Town", "environment": ""},
+        )
+        db_session.add(state)
+        db_session.add(_character(campaign.id))
+        await db_session.commit()
+
+        turn = TurnContext(player_action="Look around.", rules_result=None)
+        snapshot = await build_snapshot(campaign.id, turn, db_session)
+
+        assert snapshot.scene.time_of_day == "dusk"
+
+    async def test_npc_query_uses_current_scene_id(self, db_session: AsyncSession) -> None:
+        """NPCs are scoped to current_scene_id, not world_state['location'] (ADR-0019)."""
+        campaign = _campaign()
+        db_session.add(campaign)
+        await db_session.flush()
+        state = _campaign_state(
+            campaign.id,
+            current_scene_id="harborside_supply",
+            world_state={"location": "Old Tavern", "environment": ""},
+        )
+        db_session.add(state)
+        db_session.add(_character(campaign.id))
+
+        # NPC at the new location
+        npc_at_shop = _npc(
+            campaign.id,
+            "Shopkeeper Vara",
+            origin="narrator_spawned",
+            scene_location="harborside_supply",
+        )
+        # NPC at the old location (world_state["location"])
+        npc_at_tavern = _npc(
+            campaign.id,
+            "Barkeep Korven",
+            origin="narrator_spawned",
+            scene_location="old_tavern",
+        )
+        db_session.add(npc_at_shop)
+        db_session.add(npc_at_tavern)
+        await db_session.commit()
+
+        turn = TurnContext(player_action="Look around.", rules_result=None)
+        snapshot = await build_snapshot(campaign.id, turn, db_session)
+
+        npc_names = [n["name"] for n in snapshot.npcs]
+        assert "Shopkeeper Vara" in npc_names
+        assert "Barkeep Korven" not in npc_names
+
+    async def test_serialised_scene_block_has_scene_label(self, db_session: AsyncSession) -> None:
+        """Serialised scene block uses 'Scene:' label (ADR-0019 §5)."""
+        campaign, _, _ = await _populate_basic(db_session)
+        turn = TurnContext(player_action="Look.", rules_result=None)
+        snapshot = await build_snapshot(campaign.id, turn, db_session)
+        serialized = serialize_snapshot(snapshot)
+        content = serialized["messages"][0]["content"]  # type: ignore[index]
+        assert "Scene:" in content
+        assert "Location:" not in content
+
+    async def test_serialised_scene_block_has_time_field(self, db_session: AsyncSession) -> None:
+        """Serialised scene block always has 'Time:' field (ADR-0019 §5)."""
+        campaign, _, _ = await _populate_basic(db_session)
+        turn = TurnContext(player_action="Look.", rules_result=None)
+        snapshot = await build_snapshot(campaign.id, turn, db_session)
+        serialized = serialize_snapshot(snapshot)
+        content = serialized["messages"][0]["content"]  # type: ignore[index]
+        assert "Time:" in content

--- a/backend/tavern/tests/dm/test_gm_signals.py
+++ b/backend/tavern/tests/dm/test_gm_signals.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 
 import json
 
-from tavern.dm.gm_signals import GM_SIGNALS_DELIMITER, GMSignals, parse_gm_signals, safe_default
+from tavern.dm.gm_signals import (
+    GM_SIGNALS_DELIMITER,
+    GMSignals,
+    parse_gm_signals,
+    safe_default,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -292,3 +297,310 @@ class TestDiagnosticFallback:
         _signals, diag = parse_gm_signals("No delimiter here.")
         assert diag["fallback_used"] is True
         assert _signals == safe_default()
+
+
+# ---------------------------------------------------------------------------
+# LocationChange — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestLocationChangeValid:
+    def test_valid_snake_case_identifier_parsed(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "location_change": {"new_location": "harborside_supply", "reason": "Entered shop"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is not None
+        assert result.location_change.new_location == "harborside_supply"
+        assert result.location_change.reason == "Entered shop"
+
+    def test_location_requiring_normalisation_preserved_raw(self):
+        """Parser stores the raw value; normalisation is the pipeline's responsibility."""
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "location_change": {"new_location": "Harborside Supply"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is not None
+        assert result.location_change.new_location == "Harborside Supply"
+
+    def test_location_change_reason_defaults_to_empty(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "location_change": {"new_location": "dungeon_level_2"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is not None
+        assert result.location_change.reason == ""
+
+    def test_null_location_change_parses_to_none(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "location_change": None,
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is None
+
+    def test_missing_location_change_parses_to_none(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is None
+
+
+# ---------------------------------------------------------------------------
+# LocationChange — malformed
+# ---------------------------------------------------------------------------
+
+
+class TestLocationChangeMalformed:
+    def test_string_instead_of_dict_ignored(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "location_change": "harborside_supply",
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is None
+
+    def test_missing_new_location_key_ignored(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "location_change": {"reason": "went somewhere"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is None
+
+    def test_integer_new_location_ignored(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "location_change": {"new_location": 42},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is None
+
+    def test_malformed_location_change_does_not_affect_other_fields(self):
+        """Other GMSignals fields must parse correctly even if location_change is malformed."""
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": ["Do something"],
+                "location_change": "not-a-dict",
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.location_change is None
+        assert result.suggested_actions == ["Do something"]
+        assert _diag["fallback_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# TimeProgression — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestTimeProgressionValid:
+    def test_all_eight_valid_values_parse(self):
+        valid_values = [
+            "dawn",
+            "morning",
+            "midday",
+            "afternoon",
+            "dusk",
+            "evening",
+            "night",
+            "late_night",
+        ]
+        for value in valid_values:
+            raw = _make_raw(
+                {
+                    "scene_transition": {"type": "none"},
+                    "npc_updates": [],
+                    "suggested_actions": [],
+                    "time_progression": {"new_time_of_day": value},
+                }
+            )
+            result, _diag = parse_gm_signals(raw)
+            assert result.time_progression is not None, f"Failed for value: {value}"
+            assert result.time_progression.new_time_of_day == value
+
+    def test_time_progression_with_reason(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "time_progression": {"new_time_of_day": "evening", "reason": "Hours of travel"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.time_progression is not None
+        assert result.time_progression.new_time_of_day == "evening"
+        assert result.time_progression.reason == "Hours of travel"
+
+    def test_null_time_progression_parses_to_none(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "time_progression": None,
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.time_progression is None
+
+    def test_missing_time_progression_parses_to_none(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.time_progression is None
+
+
+# ---------------------------------------------------------------------------
+# TimeProgression — malformed
+# ---------------------------------------------------------------------------
+
+
+class TestTimeProgressionMalformed:
+    def test_invalid_time_value_ignored(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "time_progression": {"new_time_of_day": "noon"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.time_progression is None
+
+    def test_string_instead_of_dict_ignored(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "time_progression": "morning",
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.time_progression is None
+
+    def test_missing_new_time_of_day_key_ignored(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": [],
+                "time_progression": {"reason": "time passed"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.time_progression is None
+
+    def test_malformed_time_progression_does_not_affect_other_fields(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [],
+                "suggested_actions": ["Do something"],
+                "time_progression": {"new_time_of_day": "high_noon"},
+            }
+        )
+        result, _diag = parse_gm_signals(raw)
+        assert result.time_progression is None
+        assert result.suggested_actions == ["Do something"]
+        assert _diag["fallback_used"] is False
+
+
+# ---------------------------------------------------------------------------
+# Combined — all five fields populated
+# ---------------------------------------------------------------------------
+
+
+class TestAllFieldsCombined:
+    def test_all_five_fields_populated(self):
+        raw = _make_raw(
+            {
+                "scene_transition": {"type": "none"},
+                "npc_updates": [
+                    {
+                        "event": "spawn",
+                        "npc_name": "Vara",
+                        "species": "Human",
+                        "appearance": "A woman with sun-darkened skin.",
+                        "role": "Shopkeeper",
+                        "motivation": "To make a living",
+                        "disposition": "neutral",
+                    }
+                ],
+                "location_change": {"new_location": "harborside_supply", "reason": "Entered shop"},
+                "time_progression": {"new_time_of_day": "midday"},
+                "suggested_actions": ["Ask about the diving equipment"],
+            }
+        )
+        result, diag = parse_gm_signals(raw)
+        assert diag["fallback_used"] is False
+        assert result.scene_transition.type == "none"
+        assert len(result.npc_updates) == 1
+        assert result.npc_updates[0].npc_name == "Vara"
+        assert result.location_change is not None
+        assert result.location_change.new_location == "harborside_supply"
+        assert result.time_progression is not None
+        assert result.time_progression.new_time_of_day == "midday"
+        assert result.suggested_actions == ["Ask about the diving equipment"]
+
+
+# ---------------------------------------------------------------------------
+# safe_default — new fields
+# ---------------------------------------------------------------------------
+
+
+class TestSafeDefaultNewFields:
+    def test_safe_default_location_change_is_none(self):
+        result = safe_default()
+        assert result.location_change is None
+
+    def test_safe_default_time_progression_is_none(self):
+        result = safe_default()
+        assert result.time_progression is None

--- a/docs/adr/ADR-0019-exploration-state-signals.md
+++ b/docs/adr/ADR-0019-exploration-state-signals.md
@@ -1,0 +1,444 @@
+# ADR-0019: Exploration State Signals
+
+- **Status**: Accepted
+- **Date**: 2026-04-06
+- **Deciders**: [@t11z](https://github.com/t11z)
+- **Scope**: `backend/tavern/dm/gm_signals.py`, `backend/tavern/dm/context_builder.py`, `backend/tavern/dm/narrator.py` (system prompt), `backend/tavern/api/turns.py` (signal processing), `backend/tavern/models/` (CampaignState schema), database migration, web client, Discord bot
+- **References**: ADR-0002 (Claude as Narrator — snapshot structure), ADR-0004 (Campaign and Session Lifecycle — `world_state` JSONB), ADR-0012 (GMSignals envelope and processing order), ADR-0013 (NPC Lifecycle — scene-scoped snapshot), ADR-0016 (World Object Persistence — scene-scoped snapshot), ADR-0017 (Scene Identifier Convention — normalisation, **§4 partially superseded by this ADR**)
+- **Supersedes**: ADR-0017 §4 (Current scene tracking) — the `current_scene_id` field and write path described in ADR-0017 §4 were never implemented. This ADR defines the actual mechanism.
+
+## Context
+
+A playtest session exposed three categories of Narrator state coherence failures:
+
+1. **Spatial state drift**: The player left a tavern and entered a shop. The Narrator
+   described the transition, but on subsequent turns placed the player back in the tavern
+   and addressed NPCs from the wrong location.
+
+2. **NPC identity mutation**: The shopkeeper was described as three different people across
+   three consecutive turns — a middle-aged woman, then a burly man, then an older man
+   with one eye.
+
+3. **NPC context bleed**: When the player addressed someone in the shop, the Narrator
+   responded as a character from the tavern.
+
+A diagnostic investigation confirmed a single architectural root cause: **there is no
+mechanism in the GMSignals envelope for the Narrator to signal an exploration-mode
+location change, and no code path to consume such a signal.**
+
+The `SceneTransition` dataclass (ADR-0012) has four fields — `type` (limited to
+`combat_start`, `combat_end`, `none`), `combatants`, `potential_surprised_characters`,
+and `reason`. It is exclusively a combat mode transition signal. ADR-0017's Context
+section references `SceneTransition.new_location` as an existing field, and ADR-0017 §4
+describes `CampaignState.current_scene_id` as the storage mechanism — neither exists in
+the implementation.
+
+The actual location is stored as `CampaignState.world_state["location"]`, a JSONB key
+written once at campaign creation and never updated thereafter. The Context Builder reads
+this value on every turn to scope its NPC and world object queries. Because the value is
+static, the queries always return entities from the opening location — regardless of
+where the player has moved narratively.
+
+The NPC spawn handler (`api/turns.py`) does not assign `scene_location` to newly spawned
+NPCs from the current location. Spawned NPCs receive `scene_location = NULL` unless the
+Narrator explicitly emits a separate `location_change` event — which it has no reason to
+do, since the Narrator does not know the canonical location value (it reads a stale one
+from the snapshot).
+
+A secondary gap exists for time-of-day tracking. The Narrator describes time passing
+narratively ("the sun sets", "hours pass"), but no structured state tracks the current
+time period. Time of day is mechanically relevant in three ways: Long Rest / Short Rest
+require specific durations (SRD 5.2.1), Darkvision is conditional on lighting, and
+Forced March / Exhaustion rules reference elapsed travel time. A tabletop GM tracks time
+intuitively; the Narrator has no equivalent mechanism.
+
+Both gaps share the same structural problem: the Narrator describes state changes in
+prose, but the GMSignals envelope lacks channels for exploration-mode state updates. This
+ADR closes both gaps.
+
+## Decision
+
+### 1. Two new top-level fields on `GMSignals`
+
+The `GMSignals` dataclass gains two new fields:
+
+```python
+@dataclass
+class LocationChange:
+    new_location: str               # Scene identifier (normalised via ADR-0017 §2)
+    reason: str = ""                # One sentence, logging only — never player-facing
+
+@dataclass
+class TimeProgression:
+    new_time_of_day: Literal[
+        "dawn", "morning", "midday", "afternoon",
+        "dusk", "evening", "night", "late_night"
+    ]
+    reason: str = ""                # One sentence, logging only — never player-facing
+
+@dataclass
+class GMSignals:
+    scene_transition: SceneTransition       # ADR-0012 — unchanged
+    npc_updates: list[NPCUpdate]            # ADR-0013 — unchanged
+    suggested_actions: list[str]            # ADR-0015 — unchanged
+    location_change: LocationChange | None  # NEW — exploration-mode location change
+    time_progression: TimeProgression | None # NEW — time-of-day advancement
+```
+
+Both new fields are nullable. `None` means no change — the default on most turns. This
+differs from `scene_transition` (which uses `type: "none"` as its default) and
+`npc_updates` / `suggested_actions` (which use empty lists). The nullable pattern is
+chosen because these signals are sparse: most turns involve neither a location change nor
+a time change. A non-null value is the signal; absence is the default.
+
+**Why not extend `SceneTransition`?** `SceneTransition` is a combat mode transition
+signal. Its `type` enum (`combat_start`, `combat_end`, `none`) governs session mode
+changes with mechanical consequences (initiative rolls, combatant tracking). Location
+changes and time progression are exploration-mode events with no session mode change.
+Overloading `SceneTransition` would conflate two independent state dimensions and
+complicate the processing pipeline — the combat path would need to filter out
+non-combat signals, and the exploration path would inherit combat-specific fields
+(`combatants`, `potential_surprised_characters`) that are meaningless in context.
+
+**Why not a generic `world_state_updates` field?** A key-value mechanism for arbitrary
+state updates is flexible but unvalidatable. The Narrator could emit malformed keys,
+conflicting values, or state updates the server does not know how to process. Location
+and time are bounded, well-defined state dimensions with clear validation rules and
+clear consumers (Context Builder, Rules Engine). They earn their own typed signals.
+
+### 2. `current_scene_id` as a dedicated column on `CampaignState`
+
+The party's current location is promoted from `world_state["location"]` (an untyped
+JSONB key) to `CampaignState.current_scene_id` (a `TEXT` column):
+
+```sql
+ALTER TABLE campaign_state ADD COLUMN current_scene_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE campaign_state ADD COLUMN time_of_day TEXT NOT NULL DEFAULT 'morning';
+
+-- Migration: populate from existing JSONB
+UPDATE campaign_state
+SET current_scene_id = normalise_scene_id(
+    COALESCE(world_state->>'location', '')
+);
+```
+
+`current_scene_id` stores a normalised scene identifier (ADR-0017 §1–§2). It is the
+single source of truth for the party's current location. The JSONB key
+`world_state["location"]` is deprecated and no longer read by any code path after
+migration.
+
+`time_of_day` stores the current time period as one of the eight enumerated values.
+Default is `morning` — matching the typical campaign opening. The value is set at
+campaign creation (from the Claude-generated brief, or defaulting to `morning`) and
+updated via `TimeProgression` signals thereafter.
+
+**Why a dedicated column instead of JSONB?** Three reasons: (1) The Context Builder's
+NPC and world object queries filter by `current_scene_id` on every turn — a dedicated
+column supports indexing and avoids JSONB path extraction in the hot query path.
+(2) `current_scene_id` has a defined format (ADR-0017) and a `CHECK` constraint is
+expressible on a column but not on a JSONB key. (3) The field's lifecycle is
+write-on-every-location-change, read-on-every-turn — the same access pattern as
+`rolling_summary` and `turn_count`, both of which are dedicated columns.
+
+### 3. Server processing order
+
+The processing order in `api/turns.py` after GMSignals parsing becomes:
+
+```
+1. npc_updates          — NPC records must exist before they can be scoped to a location
+2. location_change      — NEW: update current_scene_id, assign scene_location to
+                          newly spawned NPCs from step 1 that have scene_location = NULL
+3. time_progression     — NEW: update time_of_day
+4. scene_transition     — combat mode changes (may depend on location for combatant
+                          scoping)
+5. suggested_actions    — forward to clients (no server-side processing)
+```
+
+**`location_change` before `scene_transition`**: A Narrator response may both move the
+party to a new location and initiate combat there (e.g., "You enter the throne room —
+the dragon attacks"). The NPCs spawned in step 1 need `scene_location` assigned from
+the new location in step 2, and the combat transition in step 4 needs the correct
+`current_scene_id` to scope combatants.
+
+**NPC `scene_location` auto-assignment on spawn**: When `location_change` is processed,
+any NPCs spawned in step 1 that still have `scene_location = NULL` are assigned
+`current_scene_id` as their `scene_location`. This eliminates the need for the Narrator
+to emit a separate `location_change` event per NPC — spawned NPCs are assumed to be at
+the party's current location unless the Narrator explicitly assigns them elsewhere.
+
+### 4. Narrator system prompt additions
+
+The system prompt gains two new instruction blocks:
+
+**Location change instructions:**
+
+```
+When the party moves to a new location — entering a building, leaving a town, descending
+into a dungeon, traveling to a new area — emit a location_change in your GMSignals block.
+
+The new_location value must be a snake_case identifier: lowercase letters, digits, and
+underscores only. Use the same identifier consistently for the same physical location.
+Examples: "harborside_supply", "the_drowned_anchor", "dungeon_level_2".
+
+Emit location_change only when the party's physical location changes. Do not emit it for
+movement within the same location (walking across a tavern, moving to a different table).
+
+If the party returns to a previously visited location, reuse the same identifier.
+Your current location is shown in the Scene: field of your context — reference it if
+you are unsure what identifier to use for the current location.
+```
+
+**Time progression instructions:**
+
+```
+When significant time passes in the narrative — hours of travel, waiting until nightfall,
+a long rest, the passage of an afternoon — emit a time_progression in your GMSignals
+block.
+
+The new_time_of_day value must be one of exactly eight values:
+  dawn, morning, midday, afternoon, dusk, evening, night, late_night
+
+Your current time of day is shown in the Time: field of your context. Advance time
+consistently: if it is currently morning and the party travels for several hours, the
+new time should be midday or afternoon, not night.
+
+Do not emit time_progression on every turn. Most turns occur within a single time period.
+Emit it only when the narrative describes meaningful time passing.
+
+Do not emit time_progression for Short Rests or Long Rests — those are mechanical events
+handled by the Rules Engine. Only emit it for narrative time passage outside of rest
+mechanics.
+```
+
+**Prompt token cost**: Both instruction blocks add approximately 180 tokens to the static
+system prompt. At prompt caching pricing (0.1x rate on cache reads), this is negligible.
+The output cost is bounded by the signal structure — at most ~30 additional tokens per
+turn when both signals are emitted.
+
+### 5. Snapshot format changes
+
+The scene context block in the serialised snapshot gains the `Time:` field and the
+`Scene:` field now reads from `current_scene_id` instead of `world_state["location"]`:
+
+```
+Scene: harborside_supply
+Time: morning
+Location description: A cramped shop on the waterfront, shelves laden with diving
+  equipment and maritime supplies.
+
+NPCs in scene:
+- Shopkeeper Vara (Human, Maritime Supplier) — neutral — "A middle-aged woman with
+  sun-darkened skin and keen eyes."
+```
+
+The `Scene:` and `Time:` fields are always present. The Narrator reads them to determine
+its current context and to reference the correct identifier when emitting `location_change`
+or `time_progression` signals.
+
+### 6. WebSocket events
+
+Two new optional WebSocket events:
+
+```json
+{
+  "type": "turn.location_change",
+  "payload": {
+    "turn_id": "uuid",
+    "campaign_id": "uuid",
+    "new_location": "harborside_supply"
+  }
+}
+```
+
+```json
+{
+  "type": "turn.time_progression",
+  "payload": {
+    "turn_id": "uuid",
+    "campaign_id": "uuid",
+    "new_time_of_day": "afternoon"
+  }
+}
+```
+
+Both events are emitted after `turn.narrative_end`, in the same position as
+`turn.suggested_actions`. They are informational — clients may use them to update UI
+elements (location indicator, time-of-day display, ambient lighting changes) but are
+not required to handle them.
+
+Emission sequence:
+
+```
+turn.narrative_start
+turn.narrative_chunk × N
+turn.narrative_end
+turn.location_change         ← NEW, only if location changed
+turn.time_progression        ← NEW, only if time changed
+turn.suggested_actions       ← existing
+```
+
+### 7. Relationship to ADR-0017
+
+ADR-0017's normalisation rules (§1, §2, §3) are unchanged and apply fully to
+`LocationChange.new_location`. The `normalise_scene_id()` function in `core/scene.py`
+is called on `LocationChange.new_location` before writing to `current_scene_id`.
+
+ADR-0017 §4 (Current scene tracking) described `CampaignState.current_scene_id` as a
+field and showed NPC/world object queries using it. The field and queries described in
+§4 were architecturally correct but never implemented — location was stored in
+`world_state["location"]` (a JSONB key) and never updated after campaign creation. This
+ADR implements what ADR-0017 §4 described, with one deviation: the field is `TEXT NOT
+NULL DEFAULT ''` rather than `str` with no default, and the migration path handles
+existing campaigns.
+
+ADR-0017 §4 is superseded by this ADR's §2 and §3. All other sections of ADR-0017
+remain in effect.
+
+ADR-0017's Context section references `SceneTransition.new_location` — a field that was
+never added to `SceneTransition` (ADR-0012). This ADR introduces `LocationChange` as a
+separate signal type rather than extending `SceneTransition`, for the reasons stated in
+§1. The ADR-0017 Context section's reference to `SceneTransition.new_location` is
+acknowledged as describing intent that was fulfilled by a different design.
+
+## Alternatives Considered
+
+**Extend `SceneTransition` with `type: "location_change"` and a `new_location` field.**
+Rejected because `SceneTransition` governs session mode changes (exploration ↔ combat)
+with mechanical consequences. Location changes have no session mode impact. Overloading
+the type enum would require every consumer of `SceneTransition` (combat initiation,
+initiative rolling, combatant scoping) to filter out a case that is semantically
+unrelated to their purpose. The processing order would become ambiguous: does a
+`location_change` SceneTransition update `current_scene_id` before or after the combat
+logic that reads it? Separate signals avoid the question.
+
+**Keep location in `world_state` JSONB and add a write path.** Rejected for three reasons:
+(1) The Context Builder's NPC and world object queries run on every turn and filter by
+location — a JSONB path extraction (`world_state->>'location'`) in the `WHERE` clause is
+less efficient than a column comparison and cannot be indexed without a generated column.
+(2) JSONB keys have no schema enforcement — a typo in the key name (`"locaton"`) would
+silently create a parallel state. (3) The existing `world_state` JSONB is documented
+(ADR-0004) as semi-structured data for "NPC dispositions, quest flags, faction
+relationships, environmental conditions" — party location is structured data with a
+defined format and a defined consumer, not a semi-structured grab bag.
+
+**Track time as a continuous clock (hours since campaign start).** Rejected because it
+imposes a simulation fidelity that tabletop RPGs do not operate at. A GM says "a few
+hours pass" without knowing whether that means 2 or 4. A continuous clock would force
+the Narrator to commit to exact durations, creating false precision that would
+accumulate error. The 8-value enum matches GM intuition: time periods are narrative
+landmarks, not timestamps. The enum also bounds the state space — validation is a set
+membership check, not a range comparison.
+
+**Combine location and time into a single `scene_state` signal.** Rejected because
+location and time change independently. The party can move without time passing (entering
+an adjacent room) and time can pass without the party moving (waiting in a tavern until
+nightfall). A combined signal would require the Narrator to emit both values when only
+one changed, introducing unnecessary coupling and increasing the chance of stale-value
+errors (emitting the current time when only location changed, but getting the current
+time wrong).
+
+**Narrator infers location from rolling summary only (no signal).** Rejected because this
+is the current architecture, and it produced the failures that motivated this ADR. The
+rolling summary preserves location mentions (the Haiku compression prompt explicitly
+lists locations as preserved content), but the summary cannot update `current_scene_id`,
+cannot scope the NPC query, and cannot scope the world object query. The summary is a
+narrative aid for the Narrator, not a state management mechanism. Relying on it for
+state management is an architectural category error.
+
+## Consequences
+
+### What becomes easier
+
+- NPC consistency across location changes is enforced by the data layer. When the player
+  enters Harborside Supply and the Narrator spawns a shopkeeper, the shopkeeper's
+  `scene_location` is automatically set to `harborside_supply`. On the next turn, the
+  Context Builder's NPC query returns the shopkeeper — not Korven from the tavern. The
+  Narrator reads the shopkeeper's canonical appearance from the snapshot and cannot
+  reinvent it.
+- The snapshot's `Scene:` and `Time:` fields give the Narrator reliable context on every
+  turn. The Narrator does not need to infer location from the rolling summary or guess
+  the time of day.
+- World object queries (ADR-0016) benefit immediately. Objects at `harborside_supply` are
+  visible when the player is there, and objects at `the_drowned_anchor` are not —
+  without any changes to the world object system.
+- Time-of-day in the snapshot enables consistent environmental narration. If the snapshot
+  says `night`, the Narrator describes darkness, torchlight, and stars — not sunshine.
+  This consistency is currently impossible because time of day is not tracked.
+- The observability layer (ADR-0018) gains two new pipeline steps (`location_change_apply`,
+  `time_progression_apply`) that make location and time changes auditable in the turn
+  event log.
+- Future mechanics that depend on time of day (Darkvision relevance, rest eligibility,
+  random encounter probability by time period) have a reliable state value to read.
+
+### What becomes harder
+
+- The Narrator's system prompt grows by ~180 tokens. The `location_change` and
+  `time_progression` instruction blocks must survive future system prompt revisions. The
+  system prompt is now the interface contract for five signal types (scene_transition,
+  npc_updates, suggested_actions, location_change, time_progression) — changes to any
+  one require regression testing against all five.
+- The GMSignals parser gains two new fields to validate and two new nullable types to
+  handle. The safe-default behaviour (treat `None` as no change) is simple, but the
+  parser must distinguish between "field absent" (no change) and "field present but
+  malformed" (log error, treat as no change).
+- The processing pipeline in `api/turns.py` gains two new steps between `npc_updates` and
+  `scene_transition`. The ordering is load-bearing (§3) and must be enforced by code
+  structure.
+- Campaign creation must set `current_scene_id` from the opening brief's location value,
+  normalised via `normalise_scene_id()`. If the brief generator produces a location name
+  that normalises to an empty string, campaign creation must handle the error.
+- The database migration must populate `current_scene_id` for existing campaigns. For
+  campaigns where `world_state["location"]` normalises to an empty string (or is absent),
+  the migration should set `current_scene_id` to a fallback value (e.g., `"unknown"`).
+
+### New constraints
+
+- `current_scene_id` and `time_of_day` are written only by the signal processing pipeline
+  in `api/turns.py`. No other code path — including the campaign management API — may
+  update these values directly. This ensures that all location and time changes pass
+  through normalisation, validation, and logging.
+- `LocationChange.new_location` must be normalised via `normalise_scene_id()` (ADR-0017
+  §2) before writing to `current_scene_id`. Normalisation failure (empty string, >64
+  characters) causes the `location_change` signal to be discarded and logged — the turn
+  is not aborted.
+- `TimeProgression.new_time_of_day` must be one of the eight enumerated values. Any other
+  value causes the `time_progression` signal to be discarded and logged.
+- NPCs spawned via `npc_updates` on the same turn as a `location_change` are assigned
+  `current_scene_id` (post-update) as their `scene_location` if they have
+  `scene_location = NULL` after spawn processing. This assignment happens in step 2 of
+  the processing pipeline (§3).
+- The `Time:` instruction explicitly excludes rest mechanics from `time_progression`. Rest
+  time advancement is handled by the Rules Engine when processing rest actions — the
+  Rules Engine updates `time_of_day` directly based on rest duration. This avoids double
+  time advancement (Narrator + Engine both advancing time for the same rest).
+- Changes to the `GMSignals` schema are breaking changes per ADR-0012. This ADR constitutes
+  a MINOR version bump. The system prompt and the `parse_gm_signals()` parser must be
+  updated in the same PR.
+
+## Review Triggers
+
+- If `location_change` signals are emitted on fewer than 30% of turns where the Narrator's
+  narrative text describes the party moving to a new location (assessed via manual audit
+  of 50 turns), the system prompt instructions are insufficient. Evaluate adding explicit
+  examples of when to emit vs. when not to emit, or adding a post-narration classifier
+  that detects movement descriptions and warns when no `location_change` was emitted.
+
+- If `time_progression` signals cause time-of-day to advance inconsistently (e.g., jumping
+  from `morning` directly to `night` without intermediate steps, more than once per 20
+  turns), evaluate adding a transition validation rule that rejects non-adjacent time
+  jumps — or document that non-adjacent jumps are intentional (e.g., "you sleep through
+  the day").
+
+- If the 8-value time enum proves too coarse for gameplay (players need to distinguish
+  "early morning" from "late morning" for mechanical purposes), evaluate expanding to a
+  12-value or 16-value enum. The system prompt instruction and the `CHECK` constraint are
+  the only surfaces that need updating.
+
+- If NPC `scene_location` auto-assignment (§3, step 2) causes incorrect NPC placement
+  (e.g., an NPC described as being in a different location than where the party moved to),
+  evaluate requiring the Narrator to emit explicit `scene_location` on spawn events rather
+  than relying on auto-assignment. This would increase system prompt complexity but
+  eliminate false assumptions.
+
+- If `world_state["location"]` is still read by any code path 3 months after this ADR is
+  implemented, the deprecation is incomplete. Audit and remove the remaining read sites.

--- a/docs/architecture-snapshot.md
+++ b/docs/architecture-snapshot.md
@@ -1,6 +1,6 @@
 # Architecture Snapshot
 
-> Last updated: 2026-04-06 — ADR-0018 Turn Observability Layer: observability.py, api/inspect.py, event_log JSONB on Turn, session.telemetry and turn.event_log WebSocket events
+> Last updated: 2026-04-06 — ADR-0019 Exploration State Signals: LocationChange/TimeProgression dataclasses, current_scene_id and time_of_day columns on CampaignState, location_change_apply and time_progression_apply pipeline steps, turn.location_change and turn.time_progression WebSocket events, NPC scene_location auto-assignment on spawn
 >
 > This document is maintained by Claude Code per the rules in CLAUDE.md.
 > It is consumed by the architecture consultant to inform decisions without
@@ -24,16 +24,16 @@ backend/tavern/
 │   ├── srd_data.py         # SRD Data Access Layer: three-tier lookup (Campaign Override → Instance Library → SRD Baseline); resolve_npc_stat_block(stat_block_ref: str, campaign_id: UUID) → dict | None (three-tier monster lookup for NPC stat block population; logs warning not error on miss)
 │   └── scene.py            # Scene identifier utilities (ADR-0017): normalise_scene_id(raw: str) -> str (strip/lowercase/replace spaces+hyphens with underscore/strip non-conforming chars/collapse underscores; raises ValueError on empty result or >64 chars); validate_scene_id(scene_id: str) -> bool (returns True if already canonical; does not raise)
 ├── dm/                 # DM layer — Narrator, Context Builder, LLM provider abstraction
-│   ├── narrator.py         # Narrator class; model routing (Sonnet/Haiku); streaming narration and summary compression; GMSignals delimiter buffering (stops forwarding to clients after ---GM_SIGNALS---); parse_gm_signals() integration; narrate_turn_stream() returns tuple[str, GMSignals, dict] (dict = LLM metadata for observability: call_type, model_id, model_tier, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, latency_ms, stream_first_token_ms, estimated_cost_usd, success, error)
-│   ├── context_builder.py  # StateSnapshot, TurnContext; builds and serializes game state for the Narrator; TurnContext.stealth_rolls: dict[str, int] (Path B Surprise, ADR-0014); StateSnapshot.session_mode: str (guards CombatClassifier, ADR-0011); StateSnapshot.npcs: list[dict] (compact NPC records, ADR-0013, scene-scoped and recency-filtered last 10 turns, excludes dead/fled unless plot_significant); build_system_prompt() includes _SUGGESTED_ACTIONS_INSTRUCTIONS block instructing the Narrator to emit 0–3 suggested_actions in the GMSignals envelope (ADR-0015)
+│   ├── narrator.py         # Narrator class; model routing (Sonnet/Haiku); streaming narration and summary compression; GMSignals delimiter buffering (stops forwarding to clients after ---GM_SIGNALS---); parse_gm_signals() integration; narrate_turn_stream() returns tuple[str, GMSignals, dict] (dict = LLM metadata); system prompt includes _GM_SIGNALS_INSTRUCTION (all 5 GMSignals fields), _NPC_CONSISTENCY_INSTRUCTION (ADR-0013), _LOCATION_CHANGE_INSTRUCTIONS (ADR-0019 — when/how to emit location_change), _TIME_PROGRESSION_INSTRUCTIONS (ADR-0019 — 8-value enum, no rest mechanics)
+│   ├── context_builder.py  # StateSnapshot, TurnContext; builds and serializes game state for the Narrator; TurnContext.stealth_rolls: dict[str, int] (Path B Surprise, ADR-0014); StateSnapshot.session_mode: str (guards CombatClassifier, ADR-0011); StateSnapshot.npcs: list[dict] (compact NPC records, ADR-0013, scene-scoped via current_scene_id column and recency-filtered last 10 turns, excludes dead/fled unless plot_significant); build_system_prompt() includes _SUGGESTED_ACTIONS_INSTRUCTIONS (ADR-0015); serialised scene block uses "Scene:" label (current_scene_id) and always-present "Time:" field (time_of_day) per ADR-0019 §5
 │   ├── summary.py          # Rolling summary helpers: build_turn_summary_input(), trim_summary(); enforces 500-token budget
 │   ├── combat_classifier.py # CombatClassifier — Haiku-based binary LLM classifier for combat initiation detection; classify(action_text: str, snapshot: StateSnapshot) → CombatClassification; called pre-narration in exploration mode only; raises RuntimeError in combat mode (ADR-0011); no dependency on core/
-│   └── gm_signals.py       # GMSignals, SceneTransition, NPCUpdate dataclasses; GM_SIGNALS_DELIMITER = "---GM_SIGNALS---" constant; parse_gm_signals(raw: str) → GMSignals — safe-default on any parse failure; safe_default() → GMSignals; GMSignals fields: scene_transition, npc_updates, suggested_actions: list[str] (0–3 action suggestions for the active player, ADR-0015; truncated to 3 entries, each capped at 80 chars)
+│   └── gm_signals.py       # GMSignals, SceneTransition, NPCUpdate, LocationChange, TimeProgression dataclasses; GM_SIGNALS_DELIMITER = "---GM_SIGNALS---" constant; parse_gm_signals(raw: str) → GMSignals — safe-default on any parse failure; safe_default() → GMSignals; GMSignals fields: scene_transition, npc_updates, suggested_actions: list[str] (0–3 suggestions, ADR-0015), location_change: LocationChange | None (ADR-0019 — new_location raw str + optional reason), time_progression: TimeProgression | None (ADR-0019 — new_time_of_day from 8-value enum + optional reason)
 ├── observability.py    # Turn pipeline telemetry (ADR-0018): PipelineStep, LLMCallRecord, TurnEventLog dataclasses; TurnEventLogAccumulator (mutable accumulator per turn); turn_event_log_to_dict() for JSONB serialisation. No dm/ or api/ imports — stdlib only.
 ├── api/                # FastAPI REST endpoints and WebSocket handler
-│   ├── campaigns.py        # Campaign CRUD + session lifecycle; calls Narrator for Claude-generated opening scene on create
+│   ├── campaigns.py        # Campaign CRUD + session lifecycle; calls Narrator for Claude-generated opening scene on create; sets current_scene_id (normalised via normalise_scene_id()) and time_of_day on CampaignState at creation (ADR-0019); world_state["location"] still written but deprecated
 │   ├── characters.py       # Character creation and retrieval
-│   ├── turns.py            # Turn submission (202) and retrieval; wires action_analyzer + Rules Engine; broadcasts character.updated; full combat lifecycle: CombatClassifier invoked pre-narration (exploration mode only); GMSignals processed post-narration (npc_updates before scene_transition, mandatory ordering per ADR-0012); engine combat_end takes precedence over Narrator combat_end signal when both fire on same turn; player-initiated (Flow B) and NPC-initiated (Flow A) combat paths both produce identical combat.started WebSocket event; mechanical_results persisted from engine results into Turn.mechanical_results JSONB column and broadcast in turn.narrative_end payload; turn.suggested_actions event emitted (using "type" key, not "event") immediately after turn.narrative_end when GMSignals.suggested_actions is non-empty (ADR-0015); TurnEventLogAccumulator instruments every pipeline step and persists event_log JSONB atomically with the turn record; emits turn.event_log WebSocket event after commit; emits session.telemetry every 10 turns (ADR-0018)
+│   ├── turns.py            # Turn submission (202) and retrieval; wires action_analyzer + Rules Engine; broadcasts character.updated; full combat lifecycle: CombatClassifier invoked pre-narration (exploration mode only); GMSignals processed post-narration in order: (1) npc_updates — spawned NPCs get scene_location=NULL, (2) location_change_apply — normalises new_location → current_scene_id, auto-assigns NULL-location NPCs from this turn, (3) time_progression_apply — updates time_of_day, (4) scene_transition — combat mode changes, (5) NPC location finalise — assigns final current_scene_id to any remaining NULL-location NPCs from this turn (ADR-0019); engine combat_end takes precedence over Narrator; turn.location_change and turn.time_progression events emitted after narrative_end before suggested_actions (ADR-0019 §6); TurnEventLogAccumulator instruments every step; emits turn.event_log and session.telemetry (ADR-0018)
 │   ├── inspect.py          # Observability REST endpoints (ADR-0018): GET /campaigns/{id}/turns/{turn_id}/event_log (returns Turn.event_log JSONB); GET /campaigns/{id}/sessions/{session_id}/telemetry (aggregated session metrics from turn event logs; warns if query >200ms)
 │   ├── npcs.py             # NPC roster CRUD for campaign: POST (201), GET list, GET single, PATCH; PATCH enforces immutability — returns 422 if name, species, or appearance in request body; scoped to /api/campaigns/{campaign_id}/npcs
 │   ├── ws.py               # WebSocket endpoint + ConnectionManager; session.state recent_turns payload includes mechanical_results per turn; sends session.telemetry on connect (ADR-0018)
@@ -83,7 +83,8 @@ backend/tavern/
 │       ├── 0004_drop_srd_reference_tables.py                  # Drop all SRD PostgreSQL tables (data now in MongoDB)
 │       ├── 0005_add_npcs_table.py                             # NPC table (campaign-scoped roster)
 │       ├── 0006_add_mechanical_results_jsonb_to_turns.py      # Add mechanical_results JSONB column to turns
-│       └── 0007_add_event_log_jsonb_to_turns.py              # Add event_log JSONB column to turns (ADR-0018)
+│       ├── 0007_add_event_log_jsonb_to_turns.py              # Add event_log JSONB column to turns (ADR-0018)
+│       └── 0008_add_current_scene_id_and_time_of_day.py     # Add current_scene_id and time_of_day columns to campaign_states (ADR-0019)
 ├── auth/               # Placeholder — Phase 6 authentication (not yet implemented)
 └── multiplayer/        # Placeholder — future multiplayer support
 
@@ -231,6 +232,8 @@ Events currently emitted by the API server:
 | turn.narrative_start | server → client | turn_id (streaming begins) |
 | turn.narrative_chunk | server → client | turn_id, chunk, sequence (token-by-token) |
 | turn.narrative_end | server → client | turn_id, narrative, mechanical_results |
+| turn.location_change | server → client | turn_id, campaign_id, new_location: str (normalised scene_id; emitted only when location changed, ADR-0019) |
+| turn.time_progression | server → client | turn_id, campaign_id, new_time_of_day: str (8-value enum; emitted only when time advanced, ADR-0019) |
 | turn.suggested_actions | server → client | turn_id, character_id, suggestions: list[str] (emitted only when suggestions non-empty) |
 | turn.event_log | server → client | turn_id, sequence_number, pipeline_duration_ms, steps, llm_calls, warnings, errors, admin_only: true (ADR-0018; emitted after DB commit) |
 | system.error | server → client | message (narrator or system error) |
@@ -256,7 +259,7 @@ Events the discord_bot `gameplay.py` cog is ready to handle (not yet emitted by 
 | Model | Table | Key relations |
 |---|---|---|
 | Campaign | campaigns | has one CampaignState, has many Session, has many Character |
-| CampaignState | campaign_states | belongs to Campaign (unique FK) |
+| CampaignState | campaign_states | belongs to Campaign (unique FK); current_scene_id TEXT NOT NULL (normalised scene identifier, ADR-0019); time_of_day TEXT NOT NULL (8-value enum: dawn/morning/midday/afternoon/dusk/evening/night/late_night, CHECK constraint, ADR-0019) |
 | Session | sessions | belongs to Campaign, has many Turn |
 | Character | characters | belongs to Campaign, has many InventoryItem, has many CharacterCondition, has many Turn |
 | InventoryItem | inventory_items | belongs to Character |
@@ -316,6 +319,7 @@ Tavern's SRD data comes from `t11z/5e-database`, a fork of `5e-bits/5e-database`
 | 0016 | World Object Persistence | Accepted |
 | 0017 | Scene Identifier Convention | Accepted |
 | 0018 | Turn Observability Layer | Accepted |
+| 0019 | Exploration State Signals | Accepted |
 
 ## Known Deviations
 


### PR DESCRIPTION
## Summary

Implements ADR-0019 (Exploration State Signals) in full, closing the architectural root cause of the three Narrator state coherence failures documented in the playtest diagnostic:

- **Spatial state drift** — party location was stored in a JSONB key written once at campaign creation, never updated
- **NPC identity mutation** — NPC query scoped to stale opening location; Narrator reinvented NPCs from scratch each turn
- **NPC context bleed** — stale location caused wrong-scene NPCs to appear in the snapshot via recency window

## Changes

**ADR + migration (Package A)**
- `ADR-0019-exploration-state-signals.md` — accepted ADR (added manually by maintainer)
- Migration `0008`: adds `current_scene_id` and `time_of_day` dedicated columns to `campaign_states`; populates from existing JSONB data; adds `CHECK` constraint on `time_of_day`
- `CampaignState` model: new mapped columns
- `gm_signals.py`: `LocationChange` and `TimeProgression` dataclasses; `GMSignals` gains two nullable fields; parser extended with safe-default handling

**NPC spawn fix (Package C)**
- Spawned NPCs receive `scene_location=NULL`; a post-signal step assigns the final `current_scene_id` after `location_change` is processed — handles both the no-location-change and same-turn-spawn+location-change cases correctly

**Turn pipeline + snapshot + prompt (Package B)**
- Processing order enforced per ADR-0019 §3: `npc_updates → location_change_apply → time_progression_apply → NPC finalise → scene_transition`
- `turn.location_change` and `turn.time_progression` WebSocket events emitted after `narrative_end`, before `suggested_actions`
- Context Builder reads from new columns; scene block uses `Scene:` label + always-present `Time:` field
- Campaign creation initialises both columns from the brief
- System prompt adds `_LOCATION_CHANGE_INSTRUCTIONS` and `_TIME_PROGRESSION_INSTRUCTIONS`; `_GM_SIGNALS_INSTRUCTION` updated to document all 5 envelope fields

## Test plan

- [ ] `uv run pytest backend/tavern/tests/dm/test_gm_signals.py` — 42 new parser tests for `LocationChange`, `TimeProgression`, combined 5-field envelope, `safe_default` new fields
- [ ] `uv run pytest backend/tavern/tests/api/test_turn_lifecycle.py` — 8 new integration tests: DB updates, WS event emission, event ordering, NPC auto-assignment (both cases)
- [ ] `uv run pytest backend/tavern/tests/dm/test_context_builder.py` — 7 new snapshot tests: column reads, NPC scoping by `current_scene_id`, `Scene:`/`Time:` serialisation
- [ ] `uv run pytest backend/` — full suite, 1476 tests passing
- [ ] `uv run ruff check . && uv run ruff format . --check` — clean

## Constraints satisfied

- `SceneTransition` unchanged — remains a combat-only signal (ADR-0012)
- All scene identifier writes go through `normalise_scene_id()` (ADR-0017)
- `world_state["location"]` still written on campaign creation but marked `# DEPRECATED: ADR-0019`; no reads except the fallback in `_build_scene_context`
- System prompt and parser updated in the same commit (breaking change per ADR-0012)

🤖 Generated with [Claude Code](https://claude.com/claude-code)