### PR TITLE
feat(web-client): combat round display with initiative tracker

### DIFF
--- a/frontend/src/components/CampaignHeader.tsx
+++ b/frontend/src/components/CampaignHeader.tsx
@@ -3,9 +3,23 @@ interface CampaignInfo {
   turn_count: number
 }
 
+interface CombatDisplayEntry {
+  id: string
+  name: string
+  initiative: number
+  surprised: boolean
+}
+
+interface CombatDisplay {
+  currentRound: number
+  currentTurnIndex: number
+  entries: CombatDisplayEntry[]
+}
+
 interface Props {
   campaign: CampaignInfo
   wsStatus: 'connecting' | 'open' | 'closed' | 'error' | 'fatal'
+  combatDisplay: CombatDisplay | null
 }
 
 const statusDot: Record<Props['wsStatus'], { color: string; label: string }> = {
@@ -16,28 +30,60 @@ const statusDot: Record<Props['wsStatus'], { color: string; label: string }> = {
   fatal: { color: 'var(--color-danger)', label: 'Campaign not found' },
 }
 
-export function CampaignHeader({ campaign, wsStatus }: Props) {
+export function CampaignHeader({ campaign, wsStatus, combatDisplay }: Props) {
   const dot = statusDot[wsStatus]
+  const activeName = combatDisplay?.entries[combatDisplay.currentTurnIndex]?.name
+
   return (
-    <header style={styles.header}>
-      <h1 style={styles.title}>{campaign.name}</h1>
-      <div style={styles.meta}>
-        <span style={styles.turns}>Turn {campaign.turn_count}</span>
-        <span style={{ ...styles.dot, color: dot.color }}>{dot.label}</span>
-      </div>
-    </header>
+    <div style={styles.wrapper}>
+      <header style={styles.header}>
+        <h1 style={styles.title}>{campaign.name}</h1>
+        <div style={styles.meta}>
+          {combatDisplay && (
+            <span style={styles.roundLabel}>
+              Round {combatDisplay.currentRound}
+              {activeName ? ` — ${activeName}'s Turn` : ''}
+            </span>
+          )}
+          <span style={{ ...styles.dot, color: dot.color }}>{dot.label}</span>
+        </div>
+      </header>
+
+      {combatDisplay && (
+        <div style={styles.initiativeStrip}>
+          {combatDisplay.entries.map((entry, i) => {
+            const isActive = i === combatDisplay.currentTurnIndex
+            return (
+              <div
+                key={entry.id}
+                style={{
+                  ...styles.pip,
+                  ...(isActive ? styles.pipActive : {}),
+                }}
+              >
+                <span style={styles.pipName}>{entry.name}</span>
+                {entry.surprised && <span style={styles.surprisedDot} title="Surprised">!</span>}
+                <span style={styles.pipInit}>{entry.initiative}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
   )
 }
 
 const styles: Record<string, React.CSSProperties> = {
+  wrapper: {
+    flexShrink: 0,
+    borderBottom: '1px solid var(--color-border)',
+    background: 'var(--color-bg-panel)',
+  },
   header: {
     display: 'flex',
     alignItems: 'baseline',
     justifyContent: 'space-between',
     padding: '0.75rem 1.25rem',
-    borderBottom: '1px solid var(--color-border)',
-    background: 'var(--color-bg-panel)',
-    flexShrink: 0,
   },
   title: {
     fontFamily: 'var(--font-serif)',
@@ -52,10 +98,58 @@ const styles: Record<string, React.CSSProperties> = {
     alignItems: 'baseline',
     fontSize: '0.8rem',
   },
-  turns: {
-    color: 'var(--color-parchment-dim)',
+  roundLabel: {
+    color: 'var(--color-danger)',
+    fontWeight: 700,
+    fontSize: '0.78rem',
+    letterSpacing: '0.04em',
   },
   dot: {
     fontSize: '0.75rem',
+  },
+  initiativeStrip: {
+    display: 'flex',
+    gap: '0.35rem',
+    overflowX: 'auto',
+    padding: '0.35rem 1.25rem 0.45rem',
+    borderTop: '1px solid rgba(192,57,43,0.2)',
+    background: 'rgba(192,57,43,0.04)',
+    scrollbarWidth: 'none' as const,
+  },
+  pip: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.3rem',
+    flexShrink: 0,
+    padding: '0.15rem 0.55rem',
+    borderRadius: '3px',
+    border: '1px solid var(--color-border)',
+    background: 'var(--color-bg-panel)',
+    fontSize: '0.7rem',
+    color: 'var(--color-parchment-dim)',
+    maxWidth: '9rem',
+    overflow: 'hidden',
+  },
+  pipActive: {
+    background: 'rgba(192,57,43,0.15)',
+    border: '1px solid var(--color-danger)',
+    color: 'var(--color-parchment)',
+    fontWeight: 600,
+  },
+  pipName: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+    flex: 1,
+  },
+  surprisedDot: {
+    color: 'var(--color-danger)',
+    fontWeight: 700,
+    flexShrink: 0,
+  },
+  pipInit: {
+    color: 'var(--color-gold-dim)',
+    flexShrink: 0,
+    fontSize: '0.65rem',
   },
 }

--- a/frontend/src/components/GameSession.tsx
+++ b/frontend/src/components/GameSession.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 import type {
   CharacterState,
-  InitiativeEntry,
+  CombatState,
   MechanicalResultEntry,
   SessionState,
   SessionTelemetry,
@@ -75,7 +75,7 @@ export function GameSession({ campaignId, onEndSession }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [ending, setEnding] = useState(false)
   const [toast, setToast] = useState<string | null>(null)
-  const [combat, setCombat] = useState<{ initiative_order: InitiativeEntry[]; surprised: string[] } | null>(null)
+  const [combat, setCombat] = useState<CombatState | null>(null)
   const [suggestions, setSuggestions] = useState<string[]>([])
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [characterSheetOpen, setCharacterSheetOpen] = useState(false)
@@ -111,7 +111,15 @@ export function GameSession({ campaignId, onEndSession }: Props) {
               narrative: t.narrative ?? null,
             })),
           )
-          setCombat(s.combat ?? null)
+          setCombat(s.combat
+            ? {
+                initiativeOrder: s.combat.initiative_order,
+                surprised: s.combat.surprised,
+                currentRound: 1,
+                currentTurnIndex: 0,
+              }
+            : null,
+          )
           if (s.characters.length > 0 && !activeCharId) {
             setActiveCharId(s.characters[0].id)
           }
@@ -178,6 +186,15 @@ export function GameSession({ campaignId, onEndSession }: Props) {
               ]
             })
           }
+          // Advance combat turn index after every turn.narrative_end
+          setCombat((prev) => {
+            if (!prev) return prev
+            const nextIndex = prev.currentTurnIndex + 1
+            if (nextIndex >= prev.initiativeOrder.length) {
+              return { ...prev, currentTurnIndex: 0, currentRound: prev.currentRound + 1 }
+            }
+            return { ...prev, currentTurnIndex: nextIndex }
+          })
           break
         }
         case 'character.updated': {
@@ -204,8 +221,10 @@ export function GameSession({ campaignId, onEndSession }: Props) {
         // combat UI only updated after reconnect (which delivers session.state).
         case 'combat.started':
           setCombat({
-            initiative_order: event.payload.initiative_order,
+            initiativeOrder: event.payload.initiative_order,
             surprised: event.payload.surprised,
+            currentRound: 1,
+            currentTurnIndex: 0,
           })
           break
         case 'combat.ended':
@@ -444,19 +463,23 @@ export function GameSession({ campaignId, onEndSession }: Props) {
         {/* Combat panel */}
         {combat && (
           <div style={s.combatPanel}>
-            <span style={s.combatBadge}>COMBAT</span>
+            <span style={s.combatBadge}>COMBAT · Round {combat.currentRound}</span>
             <div style={s.initiativeHeader}>
               <span style={s.initiativeRank}>#</span>
               <span style={{ ...s.initiativeName, color: 'var(--color-parchment-dim)', fontSize: '0.65rem', letterSpacing: '0.08em' }}>Name</span>
               <span style={{ ...s.initiativeRoll, color: 'var(--color-parchment-dim)', fontSize: '0.65rem', letterSpacing: '0.08em' }}>Init</span>
             </div>
-            {combat.initiative_order.map((entry, i) => {
+            {combat.initiativeOrder.map((entry, i) => {
               const char = session.characters.find((c) => c.id === entry.character_id)
               const name = char?.name ?? entry.character_id
-              const isSurprised = combat.surprised.includes(entry.character_id)
+              const isSurprised = combat.currentRound === 1 && combat.surprised.includes(entry.character_id)
+              const isActive = i === combat.currentTurnIndex
               return (
-                <div key={entry.character_id} style={s.initiativeEntry}>
-                  <span style={s.initiativeRank}>{i + 1}.</span>
+                <div key={entry.character_id} style={{
+                  ...s.initiativeEntry,
+                  ...(isActive ? { color: 'var(--color-parchment)', background: 'rgba(192,57,43,0.1)', borderRadius: '3px', paddingLeft: '0.25rem', marginLeft: '-0.25rem' } : {}),
+                }}>
+                  <span style={{ ...s.initiativeRank, ...(isActive ? { color: 'var(--color-danger)' } : {}) }}>{i + 1}.</span>
                   <span style={s.initiativeName}>
                     {name}
                     {isSurprised && <span style={s.surprisedMark}> !</span>}
@@ -483,7 +506,23 @@ export function GameSession({ campaignId, onEndSession }: Props) {
         {isMobile && (
           <button style={s.menuBtn} onClick={() => setSidebarOpen(true)} title="Characters">☰</button>
         )}
-        <CampaignHeader campaign={session.campaign} wsStatus={wsStatus} />
+        <CampaignHeader
+          campaign={session.campaign}
+          wsStatus={wsStatus}
+          combatDisplay={combat ? {
+            currentRound: combat.currentRound,
+            currentTurnIndex: combat.currentTurnIndex,
+            entries: combat.initiativeOrder.map((entry) => {
+              const char = session.characters.find((c) => c.id === entry.character_id)
+              return {
+                id: entry.character_id,
+                name: char?.name ?? entry.character_id,
+                initiative: entry.initiative_result,
+                surprised: combat.currentRound === 1 && combat.surprised.includes(entry.character_id),
+              }
+            }),
+          } : null}
+        />
 
         {/* Mobile tab bar */}
         <div className="log-tab-bar">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -212,6 +212,13 @@ export interface WsCombatEndedEvent {
   payload: Record<string, never>
 }
 
+export interface CombatState {
+  initiativeOrder: InitiativeEntry[]
+  surprised: string[]
+  currentRound: number
+  currentTurnIndex: number
+}
+
 export interface WsSuggestedActionsEvent {
   event: 'turn.suggested_actions'
   payload: {


### PR DESCRIPTION
## Summary

- Replaces the global `Turn N` counter in the header with a combat-mode round indicator that is only visible during active combat — during exploration the header space is empty
- Tracks `currentRound` and `currentTurnIndex` in a new `CombatState` type, derived entirely from existing WebSocket events (`combat.started`, `combat.ended`, `turn.narrative_end`) — no backend changes
- Adds a horizontal initiative strip beneath the header during combat: one pill per combatant, active combatant highlighted in red, Surprised markers shown on Round 1 only (SRD 5.2.1)
- Sidebar combat panel updated to match: shows round number in badge, highlights active combatant

## Reconnect behaviour

On reconnect, `session.state` provides `initiative_order` and `surprised` but no round number. Combat restores with `currentRound: 1, currentTurnIndex: 0` — acceptable for V1 per the task spec.

## Test plan

- [x] Start a session in exploration mode — verify no turn counter or round indicator is visible
- [x] Trigger combat — verify "Round 1 — {first combatant}'s Turn" appears in the header
- [x] Submit turns for each combatant — verify active pip advances through the initiative strip
- [x] After all combatants act, verify round increments to 2 and index wraps to 0
- [x] Surprised combatants show `!` marker in Round 1; marker is gone in Round 2+
- [x] End combat — verify round indicator and initiative strip disappear cleanly
- [x] Disconnect and reconnect mid-combat — verify combat indicator is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)